### PR TITLE
Changing to standard library conditional variable from boost:fiber

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,9 +144,19 @@ if (${TEST_ALLOCATOR} STREQUAL "NVMM")
 	add_definitions(-DSHM)
 endif()
 
+if (USE_FAM_PERSIST)
+	message(STATUS "Using FAM persist")
+	add_definitions(-DUSE_FAM_PERSIST)
+endif()
+
 if (USE_FAM_INVALIDATE)
 	message(STATUS "Using FAM invalidate")
 	add_definitions(-DUSE_FAM_INVALIDATE)
+endif()
+
+if (USE_BOOST_FIBER)
+	message(STATUS "Using Boost Fiber")
+	add_definitions(-DUSE_BOOST_FIBER)
 endif()
 
 # Use native atomics

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,8 +31,11 @@ add_subdirectory(rpc)
 
 add_library(openfam SHARED ${LIBOPENFAM_SRC})
 
-target_link_libraries(openfam fabric fammetadata grpc grpc++ grpc++_reflection nvmm boost_fiber boost_context pmix pmi2 fambitmap)
-
+if(USE_BOOST_FIBER)
+	target_link_libraries(openfam fabric fammetadata grpc grpc++ grpc++_reflection nvmm boost_fiber boost_context pmix pmi2 fambitmap)
+else()
+	target_link_libraries(openfam fabric fammetadata grpc grpc++ grpc++_reflection nvmm boost_context pmix pmi2 fambitmap)
+endif()
 add_executable (memoryserver ${MEMORYSERVER_SRC})
 
 target_link_libraries(memoryserver fabric fammetadata grpc grpc++ grpc++_reflection nvmm boost_system fambitmap)

--- a/src/common/fam_internal.h
+++ b/src/common/fam_internal.h
@@ -104,7 +104,9 @@ namespace openfam {
 #define DATAITEMID_SHIFT 1
 
 inline void openfam_persist(void *addr, uint64_t size) {
+#ifdef USE_FAM_PERSIST
     fam_persist(addr, size);
+#endif
 }
 
 inline void openfam_invalidate(void *addr, uint64_t size) {


### PR DESCRIPTION
1] By default uses std::conditional_variable, to use boost::fiber::conditional_variable compile time option is available
3] also adding changes to make both fam_invalidate and fam_persist compile time option