### PR TITLE
Fix #7: Add support for Infiniband libfabric provider

### DIFF
--- a/src/common/fam_context.h
+++ b/src/common/fam_context.h
@@ -58,6 +58,13 @@ class Fam_Context {
         numLastRxFailCnt = 0;
         numLastTxFailCnt = 0;
 
+        fi->caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC | FI_REMOTE_WRITE |
+                   FI_REMOTE_READ;
+        fi->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
+        fi->mode = 0;
+        fi->tx_attr->mode = 0;
+        fi->rx_attr->mode = 0;
+
         // Initialize ctxRWLock
         famThreadModel = famTM;
         if (famThreadModel == FAM_THREAD_MULTIPLE)

--- a/src/common/fam_libfabric.h
+++ b/src/common/fam_libfabric.h
@@ -87,22 +87,24 @@ int fabric_scatter_stride_blocking(uint64_t key, const void *local,
                                    size_t nbytes, uint64_t first,
                                    uint64_t count, uint64_t stride,
                                    fi_addr_t fiAddr, Fam_Context *famCtx,
-                                   size_t iov_limit);
+                                   size_t iov_limit, uint64_t base);
 
 int fabric_gather_stride_blocking(uint64_t key, const void *local,
                                   size_t nbytes, uint64_t first, uint64_t count,
                                   uint64_t stride, fi_addr_t fiAddr,
-                                  Fam_Context *famCtx, size_t iov_limit);
+                                  Fam_Context *famCtx, size_t iov_limit,
+                                  uint64_t base);
 
 int fabric_scatter_index_blocking(uint64_t key, const void *local,
                                   size_t nbytes, uint64_t *index,
                                   uint64_t count, fi_addr_t fiAddr,
-                                  Fam_Context *famCtx, size_t iov_limit);
+                                  Fam_Context *famCtx, size_t iov_limit,
+                                  uint64_t base);
 
 int fabric_gather_index_blocking(uint64_t key, const void *local, size_t nbytes,
                                  uint64_t *index, uint64_t count,
                                  fi_addr_t fiAddr, Fam_Context *famCtx,
-                                 size_t iov_limit);
+                                 size_t iov_limit, uint64_t base);
 void fabric_write_nonblocking(uint64_t key, const void *local, size_t nbytes,
                               uint64_t offset, fi_addr_t fiAddr,
                               Fam_Context *famCtx);
@@ -115,23 +117,25 @@ void fabric_scatter_stride_nonblocking(uint64_t key, const void *local,
                                        size_t nbytes, uint64_t first,
                                        uint64_t count, uint64_t stride,
                                        fi_addr_t fiAddr, Fam_Context *famCtx,
-                                       size_t iov_limit);
+                                       size_t iov_limit, uint64_t base);
 
 void fabric_gather_stride_nonblocking(uint64_t key, const void *local,
                                       size_t nbytes, uint64_t first,
                                       uint64_t count, uint64_t stride,
                                       fi_addr_t fiAddr, Fam_Context *famCtx,
-                                      size_t iov_limit);
+                                      size_t iov_limit, uint64_t base);
 
 void fabric_scatter_index_nonblocking(uint64_t key, const void *local,
                                       size_t nbytes, uint64_t *index,
                                       uint64_t count, fi_addr_t fiAddr,
-                                      Fam_Context *famCtx, size_t iov_limit);
+                                      Fam_Context *famCtx, size_t iov_limit,
+                                      uint64_t base);
 
 void fabric_gather_index_nonblocking(uint64_t key, const void *local,
                                      size_t nbytes, uint64_t *index,
                                      uint64_t count, fi_addr_t fiAddr,
-                                     Fam_Context *famCtx, size_t iov_limit);
+                                     Fam_Context *famCtx, size_t iov_limit,
+                                     uint64_t base);
 
 void fabric_fence(fi_addr_t fiAddr, Fam_Context *context);
 

--- a/src/common/fam_ops_libfabric.h
+++ b/src/common/fam_ops_libfabric.h
@@ -361,6 +361,10 @@ class Fam_Ops_Libfabric : public Fam_Ops {
         return serverAddrName;
     };
 
+    char *get_provider() {
+        return provider;
+    };
+
   protected:
     MemServerMap name;
     char *service;

--- a/src/fam-api/fam.cpp
+++ b/src/fam-api/fam.cpp
@@ -867,9 +867,7 @@ int fam::Impl_::validate_item(Fam_Descriptor *descriptor) {
         itemInfo = famAllocator->check_permission_get_info(descriptor);
         descriptor->bind_key(itemInfo.key);
         descriptor->set_size(itemInfo.size);
-        if (strcmp(famOptions.allocator, FAM_OPTIONS_NVMM_STR) == 0) {
-            descriptor->set_base_address(itemInfo.base);
-        }
+        descriptor->set_base_address(itemInfo.base);
     }
 
     if (key == FAM_KEY_INVALID) {

--- a/src/rpc/fam_rpc.proto
+++ b/src/rpc/fam_rpc.proto
@@ -128,7 +128,8 @@ message Fam_Dataitem_Request {
     string regionname = 7;
     uint64 size = 8;
     uint64 key = 9;
-    bool dup = 10;
+    uint64 base = 10;
+    bool dup = 11;
 }
 
 /*
@@ -141,8 +142,9 @@ message Fam_Dataitem_Response {
     uint64 offset = 2;
     uint64 size = 3;
     uint64 key = 4;
-    int32 errorcode = 5;
-    string errormsg = 6;
+    uint64 base = 5;
+    int32 errorcode = 6;
+    string errormsg = 7;
 }
 
 message Fam_Copy_Request {

--- a/src/rpc/fam_rpc_client.h
+++ b/src/rpc/fam_rpc_client.h
@@ -286,6 +286,7 @@ class Fam_Rpc_Client {
                 Fam_Descriptor *dataItem =
                     new Fam_Descriptor(globalDescriptor, nbytes);
                 dataItem->bind_key(res.key());
+                dataItem->set_base_address((void *)res.base());
                 return dataItem;
             }
         } else {
@@ -513,6 +514,7 @@ class Fam_Rpc_Client {
             } else {
                 itemInfo.key = res.key();
                 itemInfo.size = res.size();
+                itemInfo.base = (void *)res.base();
                 return itemInfo;
             }
         } else {
@@ -566,6 +568,7 @@ class Fam_Rpc_Client {
                 destGlobalDescriptor.offset = res.offset();
                 *dest = new Fam_Descriptor(destGlobalDescriptor, res.size());
                 (*dest)->bind_key(res.key());
+                (*dest)->set_base_address((void *)res.base());
             }
         } else {
             throw Fam_Allocator_Exception(FAM_ERR_GRPC,

--- a/src/rpc/fam_rpc_service_impl.h
+++ b/src/rpc/fam_rpc_service_impl.h
@@ -175,7 +175,7 @@ class Fam_Rpc_Service_Impl : public Fam_Rpc::Service {
 
     int deregister_memory(uint64_t regionId, uint64_t offset);
 
-    int register_memory(Fam_DataItem_Metadata dataitem, void *localPointer,
+    int register_memory(Fam_DataItem_Metadata dataitem, void *&localPointer,
                         uint32_t uid, uint32_t gid, uint64_t &key);
 
     int register_fence_memory();

--- a/test/microbench/fam-api-mb/fam_microbenchmark_atomic.cpp
+++ b/test/microbench/fam-api-mb/fam_microbenchmark_atomic.cpp
@@ -63,18 +63,36 @@ TEST(FamArithmaticAtomicmicrobench, FetchALLInt64) {
 
     for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(my_fam->fam_fetch_int64(item, testOffset));
+    }
+    for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(my_fam->fam_fetch_add(item, testOffset, operand2Value));
+    }
+    for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(
             my_fam->fam_fetch_subtract(item, testOffset, operand2Value));
+    }
+    for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(
             my_fam->fam_fetch_and(item, testOffset, operand2UValue));
+    }
+    for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(my_fam->fam_fetch_or(item, testOffset, operand2UValue));
+    }
+    for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(
             my_fam->fam_fetch_xor(item, testOffset, operand2UValue));
+    }
+    for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(my_fam->fam_fetch_min(item, testOffset, operand2Value));
+    }
+    for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(my_fam->fam_fetch_max(item, testOffset, operand2Value));
+    }
+    for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(my_fam->fam_compare_swap(item, testOffset,
                                                  operand1Value, operand2Value));
+    }
+    for (i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(my_fam->fam_swap(item, testOffset, operand2Value));
     }
 }
@@ -210,6 +228,21 @@ int main(int argc, char **argv) {
     EXPECT_NO_THROW(item = my_fam->fam_allocate(dataItem, test_item_size,
                                                 test_perm_mode, desc));
     EXPECT_NE((void *)NULL, item);
+    int64_t *local = (int64_t *)malloc(test_item_size);
+
+    for (int i = 0; i < 10; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_put_blocking(local, item, 0, test_item_size));
+    }
+
+    // Need to disbale profiling code for fam_fetch_int32, so that
+    // the profiling does not capture data for this dummy fetch_int32 call.
+    // We do not profile for this APIs in the above test cases.
+    uint64_t testOffset = 0;
+    for (int i = 0; i < 10; i++) {
+        EXPECT_NO_THROW(my_fam->fam_fetch_int32(item, testOffset));
+    }
+
     my_fam->fam_barrier_all();
     ret = RUN_ALL_TESTS();
 

--- a/test/microbench/fam-api-mb/fam_microbenchmark_datapath.cpp
+++ b/test/microbench/fam-api-mb/fam_microbenchmark_datapath.cpp
@@ -60,6 +60,9 @@ TEST(FamPutGet, BlockingFamPutGet) {
     for (int i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(
             my_fam->fam_put_blocking(local, item, offset, gDataSize));
+    }
+
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(
             my_fam->fam_get_blocking(local, item, offset, gDataSize));
     }
@@ -106,6 +109,8 @@ TEST(FamScatter, BlockingScatterGatherIndex) {
     for (int i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(
             my_fam->fam_scatter_blocking(local, item, count, indexes, size));
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(
             my_fam->fam_gather_blocking(local, item, count, indexes, size));
     }
@@ -163,6 +168,8 @@ TEST(FamScatter, BlockingScatterGatherIndexSize) {
     for (int i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(
             my_fam->fam_scatter_blocking(local, item, count, indexes, size));
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
         EXPECT_NO_THROW(
             my_fam->fam_gather_blocking(local, item, count, indexes, size));
     }

--- a/third-party/download.sh
+++ b/third-party/download.sh
@@ -43,7 +43,7 @@ echo "Downloading LIBFABRIC source"
 git clone https://github.com/ofiwg/libfabric.git
 cd libfabric
 git fetch --all --tags --prune
-git checkout tags/v1.7.2 -b openfam
+git checkout tags/v1.9.1rc1 -b openfam
 
 #PMIX v3.0.2
 cd $CURRENT_DIR


### PR DESCRIPTION
Code changes include:
   - support libfabric verbs provider for inifiniband
   - support MR_BASIC memory registration mode
   - Download latest libfabric code
   - Update to microbenchmark tests