### PR TITLE
Fix #10 : Adding micro benchmark tests for multiple memory server con…

### DIFF
--- a/test/multi-memnode-test/CMakeLists.txt
+++ b/test/multi-memnode-test/CMakeLists.txt
@@ -9,4 +9,8 @@ endfunction()
 
 #add tests
 add_fam_test(fam_multi_memnode_tests)
+add_fam_test(fam_datapath_for_random_regions)
+add_fam_test(fam_microbenchmark_datapath_multiple_memnodes)
+add_fam_test(fam_datapath_for_memnode_regions)
+add_fam_test(fam_microbenchmark_atomic_multiple_memnodes)
 

--- a/test/multi-memnode-test/fam_datapath_for_memnode_regions.cpp
+++ b/test/multi-memnode-test/fam_datapath_for_memnode_regions.cpp
@@ -1,0 +1,250 @@
+/*
+ * fam_datapath_for_memnode_regions.cpp
+ * Copyright (c) 2020 Hewlett Packard Enterprise Development, LP. All rights
+ * reserved. Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * See https://spdx.org/licenses/BSD-3-Clause
+ *
+ */
+/* Test Case Description: Test Program in which a region is created in each
+ * memory server and each PE will create a data item in these regions.
+ * Each PE will do put/getscatter/gather operations on these regions.
+ * Based on number of memory servers, first PEs will create regions, and
+ * other PEs lookup for created regions.
+ */
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <stdio.h>
+#include <string.h>
+
+#include <fam/fam.h>
+#include <fam/fam_exception.h>
+
+#include "common/fam_test_config.h"
+
+using namespace std;
+using namespace openfam;
+#define NUM_REGIONS 10
+
+fam *my_fam;
+Fam_Options fam_opts;
+Fam_Region_Descriptor *testRegionDesc[NUM_REGIONS];
+const char *testRegionStr;
+const char *firstItem;
+Fam_Descriptor *item[NUM_REGIONS];
+
+#define REGION_PERM 0777
+#define NUM_ITERATIONS 1000
+#define REGION_SIZE 4294967296
+uint64_t gDataSize = 256;
+int numsrv;
+
+const int MAX = 26;
+const int REGION_NAME_LEN = 10;
+
+// Returns a string of random alphabets of
+// length n.
+string getRandomString() {
+    char alphabet[MAX] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+                          'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+                          's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
+
+    string res = "";
+    for (int i = 0; i < REGION_NAME_LEN; i++)
+        res = res + alphabet[rand() % MAX];
+
+    return res;
+}
+
+const char *getRegionName(int memServerId, int totalMemservers) {
+    size_t hashVal;
+    std::string regionName;
+    do {
+        // regionName = getRandomString()  + to_string(memServerId );
+        regionName = getRandomString();
+        hashVal = hash<string>{}(regionName) % totalMemservers;
+    } while (hashVal != (size_t)memServerId);
+    cout << "[ " << memServerId << ", " << totalMemservers
+         << " ] = " << regionName << endl;
+    return (strdup(regionName.c_str()));
+}
+
+// Test case#1 - Blocking Put/Get operations in each memory server for  NUM_ITERATIONS.
+TEST(FamDatapath, BlockingPutGet) {
+    int j = 0;
+    char *local = strdup("MSG: ");
+    char *msg = (char *)malloc(gDataSize);
+    // allocate local memory to receive 20 elements
+    char *local2 = (char *)malloc(gDataSize);
+    uint64_t offset = 0;
+    while (j < NUM_ITERATIONS) {
+        sprintf(msg, "%s %d", local, j);
+        for (int i = 0; i < numsrv; i++) {
+            EXPECT_NO_THROW(
+                my_fam->fam_put_blocking(msg, item[i], offset, gDataSize));
+        }
+
+        j++;
+    }
+    j = 0;
+    offset = 0;
+    while (j < NUM_ITERATIONS) {
+        for (int i = 0; i < numsrv; i++) {
+            sprintf(msg, "%s %d", local, j);
+            EXPECT_NO_THROW(
+                my_fam->fam_get_blocking(local2, item[i], offset, gDataSize));
+        }
+
+        j++;
+    }
+    free(msg);
+    free(local2);
+}
+
+// Test case -  Non-Blocking puts in each memory server for  NUM_ITERATIONS.
+TEST(FamDatapath, NonBlockingFamPut) {
+    int i, j = 0;
+    char *local = strdup("MSG: ");
+    char *msg = (char *)malloc(gDataSize);
+    uint64_t offset = 0;
+    while (j < NUM_ITERATIONS) {
+        sprintf(msg, "%s %d", local, j);
+        for (i = 0; i < numsrv; i++) {
+            my_fam->fam_put_nonblocking(msg, item[i], offset, gDataSize);
+        }
+        j++;
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+//
+// Test case -  Non-Blocking get in each memory server for  NUM_ITERATIONS.
+//
+TEST(FamDatapath, NonBlockingFamGet) {
+    int i, j = 0;
+    uint64_t offset = 0;
+    char *local2 = (char *)malloc(gDataSize);    
+    while (j < NUM_ITERATIONS) {
+        for (i = 0; i < numsrv; i++) {
+            EXPECT_NO_THROW(my_fam->fam_get_nonblocking(
+                (void *)(local2), item[i], offset, gDataSize));
+        }
+        j++;
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+    free(local2);
+
+}
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    char *peIdOpt;
+    int *peId;
+    numsrv = 1;
+
+    for (int i = 1; i < argc; ++i) {
+        printf("arg %2d = %s\n", i, (argv[i]));
+    }
+
+    if (argc >= 2) {
+        gDataSize = atoi(argv[1]);
+        numsrv = atoi(argv[2]);
+    }
+
+    my_fam = new fam();
+    init_fam_options(&fam_opts);
+
+    EXPECT_NO_THROW(my_fam->fam_initialize("default", &fam_opts));
+    int i = 0;
+
+    peIdOpt = strdup("PE_ID");
+    peId = (int *)my_fam->fam_get_option(peIdOpt);
+    srand((numsrv));
+    // PE 0 will create a region in each memory node.
+    // Other PEs lookup for the regions before using them.
+    if ((*peId) == 0) {
+        while (i < numsrv) {
+            const char *testRegion = getRegionName(i, numsrv);
+
+            EXPECT_NO_THROW(testRegionDesc[i] = my_fam->fam_create_region(
+                                testRegion, REGION_SIZE, REGION_PERM, RAID1));
+            EXPECT_NE((void *)NULL, testRegionDesc[i]);
+            cout << "PE ID: " << *peId << "Region with name " << testRegion
+                 << " created in memory node : "
+                 << testRegionDesc[i]->get_memserver_id() << endl;
+            i++;
+        }
+        my_fam->fam_barrier_all();
+
+    } else {
+
+        my_fam->fam_barrier_all();
+        i = 0;
+        while (i < numsrv) {
+            const char *testRegion = getRegionName(i, numsrv);
+
+            EXPECT_NO_THROW(testRegionDesc[i] =
+                                my_fam->fam_lookup_region(testRegion));
+            EXPECT_NE((void *)NULL, testRegionDesc[i]);
+            cout << "PE ID: " << *peId << "Region with name " << testRegion
+                 << " looked up in memory node : "
+                 << testRegionDesc[i]->get_memserver_id() << endl;
+            i++;
+        }
+    }
+    i = 0;
+    // After all regions are created/looked up, create data item in each region
+    while (i < numsrv) {
+
+        char itemStr[20];
+        firstItem = get_uniq_str("first", my_fam);
+        sprintf(itemStr, "%s_%d", firstItem, i);
+        EXPECT_NO_THROW(item[i] = my_fam->fam_allocate(
+                            itemStr, (gDataSize), 0777, testRegionDesc[i]));
+        EXPECT_NE((void *)NULL, item[i]);
+        //	cout << "PE " << *peId << " allocated data item " << itemStr <<
+        //" in memserver " << testRegionDesc[i]->get_memserver_id() << endl;
+        i++;
+    }
+    my_fam->fam_barrier_all();
+    int ret = RUN_ALL_TESTS();
+    i = 0;
+    while (i < numsrv) {
+        EXPECT_NO_THROW(my_fam->fam_deallocate(item[i]));
+        i++;
+    }
+    // Wait for all data items to be deallocated before sestroying the regions.
+    my_fam->fam_barrier_all();
+    if (*peId == 0) {
+        i = 0;
+        while (i < numsrv) {
+            EXPECT_NO_THROW(my_fam->fam_destroy_region(testRegionDesc[i]));
+            delete testRegionDesc[i];
+            i++;
+        }
+    }
+    free((void *)testRegionStr);
+    EXPECT_NO_THROW(my_fam->fam_finalize("default"));
+    delete my_fam;
+    return ret;
+}

--- a/test/multi-memnode-test/fam_datapath_for_random_regions.cpp
+++ b/test/multi-memnode-test/fam_datapath_for_random_regions.cpp
@@ -1,0 +1,173 @@
+/*
+ * fam_datapath_for_random_regions.cpp
+ * Copyright (c) 2020 Hewlett Packard Enterprise Development, LP. All rights
+ * reserved. Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * See https://spdx.org/licenses/BSD-3-Clause
+ *
+ */
+/* Test Case Description: Test program in which each PE creates 15 regions, 
+ * a data item in each of these regions, and does datapath operations on 
+ * these data items.Regions are created randomly in any of the memory servers.
+ */
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <stdio.h>
+#include <string.h>
+
+#include <fam/fam.h>
+#include <fam/fam_exception.h>
+
+#include "common/fam_test_config.h"
+
+using namespace std;
+using namespace openfam;
+#define NUM_REGIONS 15
+
+fam *my_fam;
+Fam_Options fam_opts;
+Fam_Region_Descriptor *testRegionDesc[NUM_REGIONS];
+const char *testRegionStr;
+const char *firstItem;
+Fam_Descriptor *item[NUM_REGIONS];
+
+#define REGION_SIZE 1073741824
+#define REGION_PERM 0777
+#define NUM_ITERATIONS 1000
+uint64_t gDataSize = 256;
+
+// Test case#1 - Blocking Put/Get calls are invoked for each region for NUM_ITERATIONS.
+TEST(FamDatapath, BlockingPutGet) {
+    int j = 0;
+    unsigned offset = 0;
+    char *local = strdup("MSG: ");
+    // allocate local memory to receive gDataSize  elements
+    char *msg = (char *)malloc(gDataSize);
+    char *local2 = (char *)malloc(gDataSize);
+    sprintf(msg, "%s", local);
+    while (j < NUM_ITERATIONS) {
+        offset = (gDataSize * j) % REGION_SIZE;
+        for (int i = 0; i < NUM_REGIONS; i++) {
+            EXPECT_NO_THROW(
+                my_fam->fam_put_blocking(msg, item[i], offset, gDataSize));
+        }
+
+        j++;
+    }
+    j = 0;
+    while (j < NUM_ITERATIONS) {
+        offset = (gDataSize * j) % REGION_SIZE;
+        for (int i = 0; i < NUM_REGIONS; i++) {
+
+            EXPECT_NO_THROW(
+                my_fam->fam_get_blocking(local2, item[i], offset, gDataSize));
+        }
+
+        j++;
+    }
+    free(msg);
+    free(local2);
+}
+
+// Test case -  Non-Blocking put calls are invoked for each region for NUM_ITERATIONS.
+TEST(FamDatapath, NonBlockingFamPut) {
+    int i, j = 0;
+    unsigned offset = 0;
+    char *msg = strdup("MSG: ");
+    while (j < NUM_ITERATIONS) {
+        offset = (gDataSize * j) % REGION_SIZE;
+        for (i = 0; i < NUM_REGIONS; i++) {
+            EXPECT_NO_THROW(
+                my_fam->fam_put_nonblocking(msg, item[i], offset, gDataSize));
+        }
+        j++;
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+//
+// Test case -  Non-Blocking get calls are invoked for each region for NUM_ITERATIONS.
+//
+TEST(FamDatapath, NonBlockingFamGet) {
+    int i, j = 0;
+    unsigned offset = 0;
+    char *local2 = (char *)malloc(gDataSize);
+    while (j < NUM_ITERATIONS) {
+        for (i = 0; i < NUM_REGIONS; i++) {
+            offset = (gDataSize * j) % REGION_SIZE;
+            EXPECT_NO_THROW(my_fam->fam_get_nonblocking(
+                (void *)(local2), item[i], offset, gDataSize));
+        }
+        j++;
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    if (argc == 2)
+        gDataSize = atoi(argv[1]);
+
+    my_fam = new fam();
+    init_fam_options(&fam_opts);
+
+    EXPECT_NO_THROW(my_fam->fam_initialize("default", &fam_opts));
+    int i = 0;
+    firstItem = get_uniq_str("first", my_fam);
+    testRegionStr = get_uniq_str("test", my_fam);
+    while (i < NUM_REGIONS) {
+
+        char regionStr[20];
+        char itemStr[20];
+
+        sprintf(regionStr, "%s_%d", testRegionStr, i);
+        sprintf(itemStr, "%s_%d", firstItem, i);
+        EXPECT_NO_THROW(
+            testRegionDesc[i] = my_fam->fam_create_region(
+                regionStr, REGION_SIZE + 1048576, REGION_PERM, RAID1));
+        EXPECT_NE((void *)NULL, testRegionDesc[i]);
+        cout << "Region with name " << regionStr << " created in memory node : "
+             << testRegionDesc[i]->get_memserver_id() <<  endl;
+
+        // Allocating data items in the created region
+
+        EXPECT_NO_THROW(item[i] = my_fam->fam_allocate(
+                            itemStr, REGION_SIZE, 0777, testRegionDesc[i]));
+        EXPECT_NE((void *)NULL, item[i]);
+        i++;
+    }
+    my_fam->fam_barrier_all();
+    int ret = RUN_ALL_TESTS();
+    i = 0;
+    while (i < NUM_REGIONS) {
+        EXPECT_NO_THROW(my_fam->fam_deallocate(item[i]));
+
+        EXPECT_NO_THROW(my_fam->fam_destroy_region(testRegionDesc[i]));
+        delete testRegionDesc[i];
+        i++;
+    }
+    free((void *)testRegionStr);
+    EXPECT_NO_THROW(my_fam->fam_finalize("default"));
+    delete my_fam;
+    return ret;
+}

--- a/test/multi-memnode-test/fam_microbenchmark_atomic_multiple_memnodes.cpp
+++ b/test/multi-memnode-test/fam_microbenchmark_atomic_multiple_memnodes.cpp
@@ -1,0 +1,403 @@
+/*
+ * fam_microbenchmark_atomic_multiple_memnodes.cpp
+ * Copyright (c) 2020 Hewlett Packard Enterprise Development, LP. All rights
+ * reserved. Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * See https://spdx.org/licenses/BSD-3-Clause
+ *
+ */
+/* Test Case Description: Test Program in which a region is created in each
+ * memory server and each PE will create a data item in these regions.
+ * Each PE will do atomic operations on these regions.
+ * Based on number of memory servers, first half of PEs will create regions, and 
+ * other PEs lookup for created regions.
+ */
+#include <fam/fam_exception.h>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <stdio.h>
+#include <string.h>
+
+#include <fam/fam.h>
+
+#include "common/fam_test_config.h"
+#define NUM_ITERATIONS 10000
+#define BIG_REGION_SIZE 4096
+#define BLOCK_SIZE 1024
+#define ALL_PERM 0777
+
+using namespace std;
+using namespace openfam;
+
+const int MAX = 26;
+const int REGION_NAME_LEN = 10;
+
+// Returns a string of random alphabets of
+// length n.
+string getRandomString() {
+    char alphabet[MAX] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+                          'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+                          's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
+
+    string res = "";
+    for (int i = 0; i < REGION_NAME_LEN; i++)
+        res = res + alphabet[rand() % MAX];
+
+    return res;
+}
+
+// Function that creates a region name such that each memory node
+// gets a region.
+// Input1: memServerId - memory node ID in which region has to be created
+// Input2: totalMemservers - number of memorynodes avaialble
+// Returns region name
+//
+const char *getRegionName(int memServerId, int totalMemservers) {
+    size_t hashVal;
+    std::string regionName;
+    do {
+        // regionName = getRandomString()  + to_string(memServerId );
+        regionName = getRandomString();
+        hashVal = hash<string>{}(regionName) % totalMemservers;
+    } while (hashVal != (size_t)memServerId);
+    cout << "[ " << memServerId << ", " << totalMemservers
+         << " ] = " << regionName << endl;
+    return (strdup(regionName.c_str()));
+}
+
+fam *my_fam;
+Fam_Options fam_opts;
+Fam_Descriptor *item;
+Fam_Region_Descriptor *desc;
+mode_t test_perm_mode;
+size_t test_item_size;
+int64_t operand1Value = 0x1fffffffffffffff;
+int64_t operand2Value = 0x1fffffffffffffff;
+uint64_t operand1UValue = 0x1fffffffffffffff;
+uint64_t operand2UValue = 0x1fffffffffffffff;
+
+// Test case -  All Fetch atomics (Int64)
+TEST(FamArithmaticAtomicmicrobench, FetchInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(my_fam->fam_fetch_int64(item, testOffset));
+    }
+}
+
+TEST(FamArithmaticAtomicmicrobench, FetchAddInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(my_fam->fam_fetch_add(item, testOffset, operand2Value));
+    }
+}
+
+TEST(FamArithmaticAtomicmicrobench, FetchSubInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_fetch_subtract(item, testOffset, operand2Value));
+    }
+}
+
+TEST(FamArithmaticAtomicmicrobench, FetchAndInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_fetch_and(item, testOffset, operand2UValue));
+    }
+}
+
+TEST(FamArithmaticAtomicmicrobench, FetchOrInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(my_fam->fam_fetch_or(item, testOffset, operand2UValue));
+    }
+}
+
+TEST(FamArithmaticAtomicmicrobench, FetchXorInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_fetch_xor(item, testOffset, operand2UValue));
+    }
+}
+
+TEST(FamArithmaticAtomicmicrobench, FetchMinInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(my_fam->fam_fetch_min(item, testOffset, operand2Value));
+    }
+}
+
+TEST(FamArithmaticAtomicmicrobench, FetchMaxInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(my_fam->fam_fetch_max(item, testOffset, operand2Value));
+    }
+}
+
+TEST(FamArithmaticAtomicmicrobench, FetchCmpswapInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(my_fam->fam_compare_swap(item, testOffset,
+                                                 operand1Value, operand2Value));
+    }
+}
+
+TEST(FamArithmaticAtomicmicrobench, FetchSwapInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(my_fam->fam_swap(item, testOffset, operand2Value));
+    }
+}
+
+// Test case -  fam_set for Int64
+TEST(FamArithmaticAtomicmicrobench, SetInt64) {
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(my_fam->fam_set(item, testOffset, operand2Value));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+
+// Test case -  NonFetch add for Int64
+TEST(FamArithmaticAtomicmicrobench, NonFetchAddInt64) {
+
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+
+        EXPECT_NO_THROW(my_fam->fam_add(item, testOffset, operand2Value));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+
+// Test case -  NonFetch subtract for Int64
+TEST(FamArithmaticAtomicmicrobench, NonFetchSubInt64) {
+
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+
+        EXPECT_NO_THROW(my_fam->fam_subtract(item, testOffset, operand2Value));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+
+// Test case - NonFetch and for UInt64
+TEST(FamLogicalAtomics, NonFetchAndUInt64) {
+
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+
+        EXPECT_NO_THROW(my_fam->fam_and(item, testOffset, operand2UValue));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+
+// Test case - NonFetch or for UInt64
+TEST(FamLogicalAtomics, NonFetchOrUInt64) {
+
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+
+        EXPECT_NO_THROW(my_fam->fam_or(item, testOffset, operand2UValue));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+
+// Test case - NonFetch xor for UInt64
+TEST(FamLogicalAtomics, NonFetchXorUInt64) {
+
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+
+        EXPECT_NO_THROW(my_fam->fam_xor(item, testOffset, operand2UValue));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+
+// Test case -  NonFetch min for Int64
+TEST(FamMinMaxAtomicMicrobench, NonFetchMinInt64) {
+
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+
+        EXPECT_NO_THROW(my_fam->fam_min(item, testOffset, operand2Value));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+
+// Test case -  NonFetch max for Int64
+TEST(FamMinMaxAtomicMicrobench, NonFetchMaxInt64) {
+
+    int i;
+
+    uint64_t testOffset = 0;
+
+    for (i = 0; i < NUM_ITERATIONS; i++) {
+
+        EXPECT_NO_THROW(my_fam->fam_max(item, testOffset, operand2Value));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+}
+
+int main(int argc, char **argv) {
+    int ret;
+    ::testing::InitGoogleTest(&argc, argv);
+    char *peIdOpt;
+    int *peId;
+    int numsrv = 1;
+
+    for (int i = 1; i < argc; ++i) {
+        printf("arg %2d = %s\n", i, (argv[i]));
+    }
+
+    if (argc >= 2) {
+        numsrv = atoi(argv[2]);
+    }
+
+    my_fam = new fam();
+
+    init_fam_options(&fam_opts);
+
+    EXPECT_NO_THROW(my_fam->fam_initialize("default", &fam_opts));
+
+    peIdOpt = strdup("PE_ID");
+    peId = (int *)my_fam->fam_get_option(peIdOpt);
+    srand((*peId % numsrv));
+
+    const char *testRegion = getRegionName((*peId % numsrv), numsrv);
+
+    if ((*peId % numsrv) == *peId) {
+        EXPECT_NO_THROW(desc = my_fam->fam_create_region(
+                            testRegion, BIG_REGION_SIZE, 0777, RAID1));
+        my_fam->fam_barrier_all();
+
+    } else {
+
+        my_fam->fam_barrier_all();
+        EXPECT_NO_THROW(desc = my_fam->fam_lookup_region(testRegion));
+    }
+    cout << "PE ID: " << *peId << "Region with name " << testRegion
+         << " exists in memory node : " << desc->get_memserver_id() << endl;
+
+    const char *dataItem = get_uniq_str("firstGlobal", my_fam);
+    test_perm_mode = ALL_PERM;
+    test_item_size = BLOCK_SIZE;
+    // Allocating data items in the created region for each node
+    EXPECT_NO_THROW(item = my_fam->fam_allocate(dataItem, test_item_size,
+                                                test_perm_mode, desc));
+    EXPECT_NE((void *)NULL, item);
+
+    int64_t *local = (int64_t *)malloc(test_item_size);
+
+    for (int i = 0; i < 10; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_put_blocking(local, item, 0, test_item_size));
+    }
+
+    for (int i = 0; i < 10; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_get_blocking(local, item, 0, test_item_size));
+    }
+#if 0
+    // Need to disable profiling code for fam_fetch_int32, so that
+    // the profiling does not capture data for this dummy fetch_int32 call.
+    // We do not profile for this APIs in the above test cases.
+    uint64_t testOffset = 0;
+    for (int i = 0; i < 10; i++) {
+        EXPECT_NO_THROW(my_fam->fam_fetch_int32(item, testOffset));
+    }
+#endif
+    my_fam->fam_barrier_all();
+    ret = RUN_ALL_TESTS();
+
+    EXPECT_NO_THROW(my_fam->fam_deallocate(item));
+
+    // Ensure to deallocate all data items before destroying regions
+    my_fam->fam_barrier_all();
+
+    if ((*peId % numsrv) == *peId) {
+        EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
+    }
+
+    delete item;
+    delete desc;
+    free((void *)dataItem);
+    free((void *)testRegion);
+
+    EXPECT_NO_THROW(my_fam->fam_finalize("default"));
+    delete my_fam;
+    return ret;
+}

--- a/test/multi-memnode-test/fam_microbenchmark_atomic_multiple_memnodes.cpp
+++ b/test/multi-memnode-test/fam_microbenchmark_atomic_multiple_memnodes.cpp
@@ -28,8 +28,8 @@
  *
  */
 /* Test Case Description: Test Program in which a region is created in each
- * memory server and each PE will create a data item in these regions.
- * Each PE will do atomic operations on these regions.
+ * memory server and each PE will create a data item in one of these regions.
+ * Each PE will do atomic operations on data items crated by them in a region.
  * Based on number of memory servers, first half of PEs will create regions, and 
  * other PEs lookup for created regions.
  */

--- a/test/multi-memnode-test/fam_microbenchmark_datapath_multiple_memnodes.cpp
+++ b/test/multi-memnode-test/fam_microbenchmark_datapath_multiple_memnodes.cpp
@@ -28,10 +28,10 @@
  *
  */
 /* Test Case Description: Test Program in which a region is created in each
- * memory server and each PE will create a data item in these regions.
- * Each PE will do put/getscatter/gather operations on these regions.
- * Based on number of memory servers, first half of PEs will create regions, and
- * other PEs lookup for created regions.
+ * memory server and each PE will create a data item in one of these regions.
+ * Each PE will do put/getscatter/gather operations on the data items they have
+ * created. Based on number of memory servers, first half of PEs will create 
+ * regions, and other PEs lookup for created regions.
  */
 
 #include <fam/fam_exception.h>

--- a/test/multi-memnode-test/fam_microbenchmark_datapath_multiple_memnodes.cpp
+++ b/test/multi-memnode-test/fam_microbenchmark_datapath_multiple_memnodes.cpp
@@ -1,0 +1,328 @@
+/*
+ * fam_microbenchmark_datapath_multiple_memnodes.cpp
+ * Copyright (c) 2020 Hewlett Packard Enterprise Development, LP. All rights
+ * reserved. Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * See https://spdx.org/licenses/BSD-3-Clause
+ *
+ */
+/* Test Case Description: Test Program in which a region is created in each
+ * memory server and each PE will create a data item in these regions.
+ * Each PE will do put/getscatter/gather operations on these regions.
+ * Based on number of memory servers, first half of PEs will create regions, and
+ * other PEs lookup for created regions.
+ */
+
+#include <fam/fam_exception.h>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <stdio.h>
+#include <string.h>
+
+#include <fam/fam.h>
+
+#include "common/fam_test_config.h"
+#define NUM_ITERATIONS 1000
+#define ALL_PERM 0777
+#define BIG_REGION_SIZE 1073741824
+using namespace std;
+using namespace openfam;
+
+fam *my_fam;
+Fam_Options fam_opts;
+Fam_Descriptor *item;
+Fam_Region_Descriptor *desc;
+mode_t test_perm_mode;
+size_t test_item_size;
+
+uint64_t gDataSize = 256;
+
+const int MAX = 26;
+const int REGION_NAME_LEN = 10;
+
+// Returns a string of random alphabets of
+// length n.
+string getRandomString() {
+    char alphabet[MAX] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+                          'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+                          's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
+
+    string res = "";
+    for (int i = 0; i < REGION_NAME_LEN; i++)
+        res = res + alphabet[rand() % MAX];
+
+    return res;
+}
+
+// Function that creates a region name such that each memory node
+// gets a region.
+// Input1: memServerId - memory node ID in which region has to be created
+// Input2: totalMemservers - number of memorynodes avaialble
+// Returns region name
+const char *getRegionName(int memServerId, int totalMemservers) {
+    size_t hashVal;
+    std::string regionName;
+    do {
+        // regionName = getRandomString()  + to_string(memServerId );
+        regionName = getRandomString();
+        hashVal = hash<string>{}(regionName) % totalMemservers;
+    } while (hashVal != (size_t)memServerId);
+    cout << "[ " << memServerId << ", " << totalMemservers
+         << " ] = " << regionName << endl;
+    return (strdup(regionName.c_str()));
+}
+
+// Test case -  Blocking put get test.
+TEST(FamPutGet, BlockingFamPutGet) {
+    int64_t *local = (int64_t *)malloc(gDataSize);
+    unsigned int offset = 0;
+
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_put_blocking(local, item, offset, gDataSize));
+    }
+
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_get_blocking(local, item, offset, gDataSize));
+    }
+    free(local);
+}
+
+// Test case -  Non-Blocking get test.
+TEST(FamPutGet, NonBlockingFamGet) {
+    int64_t *local = (int64_t *)malloc(gDataSize);
+    unsigned int offset = 0;
+    // Put all data first
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_get_nonblocking(local, item, offset, gDataSize));
+    }
+    // Wait for I/os to complete
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+    free(local);
+}
+
+// Test case -  Non-Blocking put test.
+TEST(FamPutGet, NonBlockingFamPut) {
+    int64_t *local = (int64_t *)malloc(gDataSize);
+    unsigned int offset = 0;
+    // Put all data first
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_put_nonblocking(local, item, offset, gDataSize));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+    free(local);
+}
+
+// Test case -  Blocking scatter and gather (Index) test.
+TEST(FamScatter, BlockingScatterGatherIndex) {
+    int64_t *local = (int64_t *)malloc(gDataSize);
+    int count = 4;
+    int64_t size = gDataSize / count;
+    uint64_t *indexes = (uint64_t *)malloc(count * sizeof(uint64_t));
+
+    for (int e = 0; e < count; e++) {
+        indexes[e] = e;
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_scatter_blocking(local, item, count, indexes, size));
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_gather_blocking(local, item, count, indexes, size));
+    }
+    free(local);
+}
+
+// Test case -  Non-Blocking scatter (Index) test.
+TEST(FamScatter, NonBlockingScatterIndex) {
+
+    int64_t *local = (int64_t *)malloc(gDataSize);
+    int count = 4;
+    int64_t size = gDataSize / count;
+    uint64_t *indexes = (uint64_t *)malloc(count * sizeof(uint64_t));
+
+    for (int e = 0; e < count; e++) {
+        indexes[e] = e;
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_scatter_nonblocking(local, item, count, indexes, size));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+    free(local);
+}
+
+// Test case -  Non-Blocking gather (Index) test.
+TEST(FamScatter, NonBlockingGatherIndex) {
+
+    int64_t *local = (int64_t *)malloc(gDataSize);
+    int count = 4;
+    int64_t size = gDataSize / count;
+    uint64_t *indexes = (uint64_t *)malloc(count * sizeof(uint64_t));
+
+    for (int e = 0; e < count; e++) {
+        indexes[e] = e;
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_gather_nonblocking(local, item, count, indexes, size));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+    free(local);
+}
+
+// Test case -  Blocking scatter and gather (Index) test (Full size).
+TEST(FamScatter, BlockingScatterGatherIndexSize) {
+    int count = 4;
+    int64_t *local = (int64_t *)malloc(gDataSize * count);
+    int64_t size = gDataSize;
+    uint64_t *indexes = (uint64_t *)malloc(count * sizeof(uint64_t));
+
+    for (int e = 0; e < count; e++) {
+        indexes[e] = e;
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_scatter_blocking(local, item, count, indexes, size));
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_gather_blocking(local, item, count, indexes, size));
+    }
+    free(local);
+}
+
+// Test case -  Non-Blocking scatter (Index) test (Full size).
+TEST(FamScatter, NonBlockingScatterIndexSize) {
+
+    int count = 4;
+    int64_t *local = (int64_t *)malloc(gDataSize * count);
+    int64_t size = gDataSize;
+    uint64_t *indexes = (uint64_t *)malloc(count * sizeof(uint64_t));
+
+    for (int e = 0; e < count; e++) {
+        indexes[e] = e;
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_scatter_nonblocking(local, item, count, indexes, size));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+    free(local);
+}
+
+// Test case -  Non-Blocking gather (Index) test (Full size).
+TEST(FamScatter, NonBlockingGatherIndexSize) {
+
+    int count = 4;
+    int64_t *local = (int64_t *)malloc(gDataSize * count);
+    int64_t size = gDataSize;
+    uint64_t *indexes = (uint64_t *)malloc(count * sizeof(uint64_t));
+
+    for (int e = 0; e < count; e++) {
+        indexes[e] = e;
+    }
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+        EXPECT_NO_THROW(
+            my_fam->fam_gather_nonblocking(local, item, count, indexes, size));
+    }
+    EXPECT_NO_THROW(my_fam->fam_quiet());
+    free(local);
+}
+
+int main(int argc, char **argv) {
+    int ret;
+    ::testing::InitGoogleTest(&argc, argv);
+    char *peIdOpt;
+    int *peId;
+    int numsrv = 1;
+
+    for (int i = 1; i < argc; ++i) {
+        printf("arg %2d = %s\n", i, (argv[i]));
+    }
+
+    if (argc >= 2) {
+        gDataSize = atoi(argv[1]);
+        numsrv = atoi(argv[2]);
+    }
+
+    my_fam = new fam();
+
+    init_fam_options(&fam_opts);
+
+    EXPECT_NO_THROW(my_fam->fam_initialize("default", &fam_opts));
+
+    // Following piece of code is used to get region name such that each memory
+    // node gets a region to work with.
+    peIdOpt = strdup("PE_ID");
+    peId = (int *)my_fam->fam_get_option(peIdOpt);
+    srand((*peId % numsrv));
+
+    const char *testRegion = getRegionName((*peId % numsrv), numsrv);
+    // First half of compute nodes/PEs create region, rest of them lookup for
+    // the same region.
+    if ((*peId % numsrv) == *peId) {
+        EXPECT_NO_THROW(desc = my_fam->fam_create_region(
+                            testRegion, BIG_REGION_SIZE, 0777, RAID1));
+        my_fam->fam_barrier_all();
+
+    } else {
+
+        my_fam->fam_barrier_all();
+        EXPECT_NO_THROW(desc = my_fam->fam_lookup_region(testRegion));
+    }
+    cout << "PE ID: " << *peId << "Region with name " << testRegion
+         << " created in memory node : " << desc->get_memserver_id() << endl;
+
+    // Create data item for each compute node(PE)
+    const char *dataItem = get_uniq_str("firstGlobal", my_fam);
+    test_perm_mode = ALL_PERM;
+    test_item_size = gDataSize * 4;
+    // Allocating data items in the created region
+    EXPECT_NO_THROW(item = my_fam->fam_allocate(dataItem, test_item_size,
+                                                test_perm_mode, desc));
+    EXPECT_NE((void *)NULL, item);
+    my_fam->fam_barrier_all();
+    ret = RUN_ALL_TESTS();
+
+    EXPECT_NO_THROW(my_fam->fam_deallocate(item));
+    // Ensure all data items are deallocated before destroying the regions.
+    my_fam->fam_barrier_all();
+
+    if ((*peId % numsrv) == *peId) {
+        EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
+    }
+    delete item;
+    delete desc;
+    free((void *)dataItem);
+    free((void *)testRegion);
+
+    EXPECT_NO_THROW(my_fam->fam_finalize("default"));
+    delete my_fam;
+    return ret;
+}


### PR DESCRIPTION
Updated test scenarios that cover few scenarios of multiple memory server testing

-   test/multi-memnode-test/fam_datapath_for_memnode_regions.cpp
-   test/multi-memnode-test/fam_datapath_for_random_regions.cpp
-   test/multi-memnode-test/fam_microbenchmark_atomic_multiple_memnodes.cpp
-   test/multi-memnode-test/fam_microbenchmark_datapath_multiple_memnodes.cpp
