### PR TITLE
Fix the ordering of link directories in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,14 +28,6 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 #
-# default system include and link directories
-#
-link_directories(/usr/lib)
-include_directories(/usr/include)
-link_directories(/usr/local/lib)
-include_directories(/usr/local/include)
-
-#
 # build type: Release (default) or Debug
 #
 message(STATUS "====================")
@@ -120,6 +112,14 @@ include_directories(${PROJECT_SOURCE_DIR}/src/pmi) # private headers (src)
 # library directories
 #
 link_directories(${PROJECT_SOURCE_DIR}/third-party/build/lib) # third-party libraries
+
+#
+# default system include and link directories
+#
+link_directories(/usr/lib)
+include_directories(/usr/include)
+link_directories(/usr/local/lib)
+include_directories(/usr/local/include)
 
 #
 # Set openFAM options to be used only by test. Some individual test cases might override these options. 

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -30,8 +30,8 @@
 
 #!/bin/bash
 CURRENTDIR=`pwd`
-export PATH="$PATH:$CURRENTDIR/../../third-party/build/bin/"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CURRENTDIR/../../third-party/build/lib"
+export PATH="$CURRENTDIR/../../third-party/build/bin/:$PATH"
+export LD_LIBRARY_PATH="$CURRENTDIR/../../third-party/build/lib:$LD_LIBRARY_PATH"
 
 if [ $# -lt 1 ]
 then


### PR DESCRIPTION
     Change the ordering of link_directories such that third-party
     lib directory is given more precedence than system wide
     libraries.