### PR TITLE
Fix #15: Destroy Region should unregister all dataitem memory

### DIFF
--- a/src/common/fam_ops_libfabric.h
+++ b/src/common/fam_ops_libfabric.h
@@ -58,6 +58,13 @@ using MemServerMap = std::map<uint64_t, std::string>;
 
 namespace openfam {
 
+typedef struct {
+    uint64_t regionId;
+    std::map<uint64_t, fid_mr *> *fiRegionMrs;
+    pthread_rwlock_t fiRegionLock;
+} Fam_Region_Map_t;
+
+
 class Fam_Ops_Libfabric : public Fam_Ops {
   public:
     ~Fam_Ops_Libfabric();
@@ -317,7 +324,7 @@ class Fam_Ops_Libfabric : public Fam_Ops {
     std::vector<fi_addr_t> *get_fiAddrs() {
         return fiAddrs;
     };
-    std::map<uint64_t, fid_mr *> *get_fiMrs() {
+    std::map<uint64_t, Fam_Region_Map_t *> *get_fiMrs() {
         return fiMrs;
     };
     Fam_Context *get_defaultCtx(uint64_t nodeId) {
@@ -341,7 +348,7 @@ class Fam_Ops_Libfabric : public Fam_Ops {
         else
             return obj->second;
     };
-    pthread_mutex_t *get_mr_lock() {
+    pthread_rwlock_t *get_mr_lock() {
         return &fiMrLock;
     };
 
@@ -379,11 +386,11 @@ class Fam_Ops_Libfabric : public Fam_Ops {
     size_t serverAddrNameLen;
     void *serverAddrName;
 
-    pthread_mutex_t fiMrLock;
+    pthread_rwlock_t fiMrLock;
     pthread_mutex_t ctxLock;
 
     std::vector<fi_addr_t> *fiAddrs;
-    std::map<uint64_t, fid_mr *> *fiMrs;
+    std::map<uint64_t, Fam_Region_Map_t *> *fiMrs;
 
     std::map<uint64_t, Fam_Context *> *contexts;
     std::map<uint64_t, Fam_Context *> *defContexts;

--- a/src/rpc/fam_rpc_service_impl.h
+++ b/src/rpc/fam_rpc_service_impl.h
@@ -176,12 +176,14 @@ class Fam_Rpc_Service_Impl : public Fam_Rpc::Service {
     bool shouldShutdown;
     pthread_mutex_t casLock[CAS_LOCK_CNT];
 
-    std::map<uint64_t, fid_mr *> *fiMrs;
+    std::map<uint64_t, Fam_Region_Map_t *> *fiMrs;
+    fid_mr *fenceMr;
 
     uint64_t generate_access_key(uint64_t regionId, uint64_t dataitemId,
                                  bool permission);
 
     int deregister_memory(uint64_t regionId, uint64_t offset);
+    int deregister_region_memory(uint64_t regionId);
 
     int register_memory(Fam_DataItem_Metadata dataitem, void *&localPointer,
                         uint32_t uid, uint32_t gid, uint64_t &key);


### PR DESCRIPTION
Destroy region operation at memory server unregister all the dataitem memory registered in libfabric.
