### PR TITLE
Removing "make test" from nvmm_build.sh

### DIFF
--- a/src/common/fam_libfabric.cpp
+++ b/src/common/fam_libfabric.cpp
@@ -230,11 +230,10 @@ void libfabric_dump_profile_summary(void) {
 #else
 
 #define LIBFABRIC_PROFILE_START_OPS()
-#define LIBFABRIC_PROFILE_END_OPS()
+#define LIBFABRIC_PROFILE_END_OPS(apiIdx)
 #define LIBFABRIC_PROFILE_START_TIME()
 #define LIBFABRIC_PROFILE_INIT()
 #define LIBFABRIC_PROFILE_END()
-#define LIBFABRIC_PROFILE_ADD_TO_TOTAL_OPS(apiIdx, total)
 #endif
 
 #define FI_CALL(retType, funcname, ...)                                        \

--- a/third-party/nvmm_build.sh
+++ b/third-party/nvmm_build.sh
@@ -71,10 +71,4 @@ then
         echo "NVMM make failed, exiting..."
         exit 1
 fi
-make test
-if [[ $? > 0 ]]
-then
-        echo "Some or all of NVMM tests failed, exiting..."
-        exit 1
-fi
 


### PR DESCRIPTION
1] Removing "make test" from nvmm_build.sh and 
2] Fixing preprocessor issue in fam_libfabric.cpp