### PR TITLE
Fix OpenFAM build failure with latest googletest

### DIFF
--- a/third-party/build.sh
+++ b/third-party/build.sh
@@ -195,7 +195,7 @@ then
         exit 1
 fi
 cd $CURRENT_DIR
-
+export CMAKE_PREFIX_PATH=$ABS_BUILD_DIR/include:$ABS_BUILD_DIR/lib
 #Install nvmm
 cd ./nvmm
 ../nvmm_build.sh

--- a/third-party/download.sh
+++ b/third-party/download.sh
@@ -62,9 +62,9 @@ tar -zxvf openmpi-4.0.1.tar.gz >/dev/null
 #GOOGLETEST 
 cd $CURRENT_DIR
 echo "Downloading GOOGLETEST source"
-git clone https://github.com/google/googletest.git googletest_master
-cp -fr googletest_master/googletest .
-rm -fr googletest_master
+git clone --branch v1.10.x https://github.com/google/googletest.git googletest_v1_10_x
+cp -fr googletest_v1_10_x/googletest .
+rm -fr googletest_v1_10_x
 
 #NVMM
 cd $CURRENT_DIR


### PR DESCRIPTION
     With master branch of latest googletest OpenFAM build test fails with

     CMake Error at third-party/googletest/CMakeLists.txt:129
     (set_target_properties):
     set_target_properties called with incorrect number of arguments.

     Fix this by using "v1.10.x" version of googletest.

     Also pass CMAKE_PREFIX_PATH to NVMM, this is used to take libpmem
     library from third-party.