### PR TITLE
Add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,120 @@
+# Works with clang-format-6.0 to clang-format-9
+# This file is created using command 
+#  clang-format-6.0 -i -style="{BasedOnStyle: llvm, IndentWidth: 4}"  -dump-config > .clang-format
+# Use below command to apply the format
+#  clang-format-6.0  -i -verbose  -style=file <filename.cpp>
+#  OR
+#  git-clang-format --style=file -v --extensions cpp,h
+#
+# Refer to CONTRIBUTING.md for usage guidelines
+#
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,30 @@ As a developer, you can push the changes from your devel branch to your reposito
 
 Note that push will only push the changes to your forked repository in github.  
 
+## Code formating
+We use git-clang-format tool to maintain the code format. Refer to ".clang-format" file for clang-format parameters.
+Before commit (after staging changes using git add) please run git-clang-format.
+Follow the below steps:
+    
+1. Make sure git-clang-format (>=6.0 or <=9) is installed in the system.  
+   In Ubuntu the binary is found in clang-format-6.0 package (>=6.0 and <=9).  
+   In Centos the package is "llvm-toolset-7.0-git-clang-format-7.0.1-1.el7.x86_64".  
+   It is dependent on llvm-toolset-7.0-clang-libs-7.0.1-1.el7.x86_64 and 
+   llvm-toolset-7.0-clang-7.0.1-1.el7.x86_64.
+2. Add git-clang-format location to PATH.   
+   In Ubuntu the default path is /usr/lib/llvm-6.0/bin/  
+   In Centos the default path is /opt/rh/llvm-toolset-7.0/root/usr/bin/  
+3. Add the modified files to staging area. (using command git add).  
+4. Run git-clang-format command -  
+   git-clang-format --style=file -v --extensions cpp,h  
+5. Verify the changes using git diff.
+6. Stage the changes and commit. 
+
+Note : To install the package in Centos you might have to do these:  
+sudo yum install yum-utils  
+sudo yum install centos-release-scl  
+sudo yum-config-manager --enable rhel-server-rhscl-7-rpms  
+
 ## Submit the changes to the mainline  
 When your changes in forked repository are ready to be committed to the mainline initiate a pull request.  
 This can be triggered by clicking on the green button on the left top corner in [your repository](https://github.com/your-user-name/OpenFAM)


### PR DESCRIPTION
    Added .clang-format file. This file is created using clang-format-6.0.

      clang-format-6.0 -i -style="{BasedOnStyle: llvm, IndentWidth: 4}" \
       -dump-config > .clang-format
    Use below command to apply the format
      clang-format-6.0  -i -verbose  -style=file <filename.cpp>