### PR TITLE
Fix #23: Uniform exception handling across all OpenFAM APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 build/
-src/rpc/fam_rpc.grpc.pb.cc
-src/rpc/fam_rpc.grpc.pb.h
-src/rpc/fam_rpc.pb.cc
-src/rpc/fam_rpc.pb.h
+src/cis/fam_cis_rpc.grpc.pb.cc
+src/cis/fam_cis_rpc.grpc.pb.h
+src/cis/fam_cis_rpc.pb.cc
+src/cis/fam_cis_rpc.pb.h
 third-party/build/
 third-party/grpc/
 third-party/libfabric/

--- a/examples/api/api_fam_add.cpp
+++ b/examples/api/api_fam_add.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_allocate_deallocate.cpp
+++ b/examples/api/api_fam_allocate_deallocate.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_and.cpp
+++ b/examples/api/api_fam_and.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_change_permission.cpp
+++ b/examples/api/api_fam_change_permission.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_compare_swap.cpp
+++ b/examples/api/api_fam_compare_swap.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_copy.cpp
+++ b/examples/api/api_fam_copy.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_create_destroy_region.cpp
+++ b/examples/api/api_fam_create_destroy_region.cpp
@@ -42,9 +42,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program
@@ -65,7 +64,7 @@ int main(void) {
         myFam->fam_destroy_region(rd);
         printf("fam_destroy_region successfull\n");
 
-    } catch (Fam_Allocator_Exception &e) {
+    } catch (Fam_Exception &e) {
         printf("Create/Destroy region failed: %d: %s\n", e.fam_error(),
                e.fam_error_msg());
         ret = -1;

--- a/examples/api/api_fam_fence.cpp
+++ b/examples/api/api_fam_fence.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_fetch.cpp
+++ b/examples/api/api_fam_fetch.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_fetch_add.cpp
+++ b/examples/api/api_fam_fetch_add.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_fetch_and.cpp
+++ b/examples/api/api_fam_fetch_and.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_fetch_max.cpp
+++ b/examples/api/api_fam_fetch_max.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_fetch_min.cpp
+++ b/examples/api/api_fam_fetch_min.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_fetch_or.cpp
+++ b/examples/api/api_fam_fetch_or.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_fetch_subtract.cpp
+++ b/examples/api/api_fam_fetch_subtract.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_fetch_xor.cpp
+++ b/examples/api/api_fam_fetch_xor.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_gather.cpp
+++ b/examples/api/api_fam_gather.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_get_blocking.cpp
+++ b/examples/api/api_fam_get_blocking.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_get_nonblocking.cpp
+++ b/examples/api/api_fam_get_nonblocking.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_get_option.cpp
+++ b/examples/api/api_fam_get_option.cpp
@@ -42,9 +42,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_initialze.cpp
+++ b/examples/api/api_fam_initialze.cpp
@@ -42,9 +42,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_list_options.cpp
+++ b/examples/api/api_fam_list_options.cpp
@@ -42,9 +42,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_lookup.cpp
+++ b/examples/api/api_fam_lookup.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.what());
         myFam->fam_abort(-1); // abort the program
@@ -81,7 +80,7 @@ int main(void) {
             myFam->fam_lookup("myItem", "myRegion");
         if (myregion != NULL && arrayDescriptor != NULL)
             printf("Lookup APIs successful!\n");
-    } catch (Fam_Allocator_Exception &e) {
+    } catch (Fam_Exception &e) {
         printf("Look up failed: %d: %s\n", e.fam_error(), e.what());
         ret = -1;
     }

--- a/examples/api/api_fam_map.cpp
+++ b/examples/api/api_fam_map.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_max.cpp
+++ b/examples/api/api_fam_max.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_min.cpp
+++ b/examples/api/api_fam_min.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_or.cpp
+++ b/examples/api/api_fam_or.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_put_blocking.cpp
+++ b/examples/api/api_fam_put_blocking.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_quiet.cpp
+++ b/examples/api/api_fam_quiet.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_resize_region.cpp
+++ b/examples/api/api_fam_resize_region.cpp
@@ -42,9 +42,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program
@@ -68,7 +67,7 @@ int main(void) {
         myFam->fam_destroy_region(rd);
         printf("fam_destroy_region successfull\n");
 
-    } catch (Fam_Allocator_Exception &e) {
+    } catch (Fam_Exception &e) {
         printf("Create/Destroy region failed: %d: %s\n", e.fam_error(),
                e.fam_error_msg());
         ret = -1;

--- a/examples/api/api_fam_scatter.cpp
+++ b/examples/api/api_fam_scatter.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_set.cpp
+++ b/examples/api/api_fam_set.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_subtract.cpp
+++ b/examples/api/api_fam_subtract.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_swap.cpp
+++ b/examples/api/api_fam_swap.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/examples/api/api_fam_xor.cpp
+++ b/examples/api/api_fam_xor.cpp
@@ -44,9 +44,8 @@ int main(void) {
     // assume that no specific options are needed by the implementation
     fm->runtime = strdup("NONE");
     try {
-        if (myFam->fam_initialize("myApplication", fm) == 0) {
-            printf("FAM initialized\n");
-        }
+        myFam->fam_initialize("myApplication", fm);
+        printf("FAM initialized\n");
     } catch (Fam_Exception &e) {
         printf("FAM Initialization failed: %s\n", e.fam_error_msg());
         myFam->fam_abort(-1); // abort the program

--- a/include/fam/fam.h
+++ b/include/fam/fam.h
@@ -1,8 +1,8 @@
 /*
  * fam.h
- * Copyright (c) 2017, 2018 Hewlett Packard Enterprise Development, LP. All
- * rights reserved. Redistribution and use in source and binary forms, with or
- * without modification, are permitted provided that the following conditions
+ * Copyright (c) 2017, 2018, 2020 Hewlett Packard Enterprise Development, LP.
+ * All rights reserved. Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the following conditions
  * are met:
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
@@ -39,6 +39,10 @@
  * to OpenFAM-API version 1.04 Modified Oct 5, 2018, by Sharad Singhal to
  * include C++ definitions Modifed Oct 22, 2018 by Sharad Singhal to separate
  * out C and C11 definitions
+ * Modified July 14, 2020, by Faizan Barmawer to add fam_stat API definition,
+ * change signature of fam_initialize, fam_resize_region, fam_copy,
+ * fam*_blocking APIs, fam_change_permissions and removed fam_size API
+ * definition
  *
  * Work in progress, UNSTABLE
  * Uses _Generic and 128-bit integer types, tested under gcc 6.3.0. May require

--- a/include/fam/fam.h
+++ b/include/fam/fam.h
@@ -273,7 +273,6 @@ class fam {
      * method called when a process uses the OpenFAM library.
      * @param groupName - name of the group of cooperating PEs.
      * @param options - options structure containing initialization choices
-     * @return - {true(0), false(1), errNo(<0)}
      * @see #fam_finalize()
      * @see #Fam_Options
      */
@@ -376,8 +375,6 @@ class fam {
      * @param descriptor - descriptor associated with the previously created
      * region
      * @param nbytes - new requested size of the allocated space
-     * @return - 0 on success, 1 for unsuccessful completion, negative number on
-     * an exception
      * @see #fam_create_region
      * @see #fam_destroy_region
      */
@@ -412,8 +409,6 @@ class fam {
      * Change permissions associated with a data item descriptor.
      * @param descriptor - descriptor associated with some data item
      * @param accessPermissions - new permissions for the data item
-     * @return - 0 on success, 1 for unsuccessful completion, negative number on
-     * an exception
      */
     void fam_change_permissions(Fam_Descriptor *descriptor,
                                 mode_t accessPermissions);
@@ -422,8 +417,6 @@ class fam {
      * Change permissions associated with a region descriptor.
      * @param descriptor - descriptor associated with some region
      * @param accessPermissions - new permissions for the region
-     * @return - 0 on success, 1 for unsuccessful completion, negative number on
-     * an exception
      */
     void fam_change_permissions(Fam_Region_Descriptor *descriptor,
                                 mode_t accessPermissions);
@@ -461,8 +454,6 @@ class fam {
      * @param offset - byte offset within the space defined by the descriptor
      * from where memory should be copied
      * @param nbytes - number of bytes to be copied from global to local memory
-     * @return - 0 for successful completion, 1 for unsuccessful, and a negative
-     * number in case of exceptions
      */
     void fam_get_blocking(void *local, Fam_Descriptor *descriptor,
                           uint64_t offset, uint64_t nbytes);
@@ -488,8 +479,6 @@ class fam {
      * @param offset - byte offset within the region defined by the descriptor
      * to where data should be copied
      * @param nbytes - number of bytes to be copied from local to FAM
-     * @return - 0 for successful completion, 1 for unsuccessful completion,
-     * negative number in case of exceptions
      */
     void fam_put_blocking(void *local, Fam_Descriptor *descriptor,
                           uint64_t offset, uint64_t nbytes);
@@ -544,8 +533,6 @@ class fam {
      * access
      * @param stride - stride in elements
      * @param elementSize - size of the element in bytes
-     * @return - 0 for normal completion, 1 in case of unsuccessful completion,
-     * negative number in case of exception
      * @see #fam_scatter_strided
      */
     void fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
@@ -564,8 +551,6 @@ class fam {
      * @param nElements - number of elements to be gathered in local memory
      * @param elementIndex - array of element indexes in FAM to fetch
      * @param elementSize - size of each element in bytes
-     * @return - 0 for normal completion, 1 in case of unsuccessful completion,
-     * negative number in case errors
      * @see #fam_scatter_indexed
      */
     void fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
@@ -623,8 +608,6 @@ class fam {
      * the strided access
      * @param stride - stride in elements
      * @param elementSize - size of each element in bytes
-     * @return - 0 for normal completion, 1 in case of unsuccessful completion,
-     * negative number in case errors
      * @see #fam_gather_strided
      */
     void fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
@@ -642,8 +625,6 @@ class fam {
      * @param nElements - number of elements to be scattered from local memory
      * @param elementIndex - array containing element indexes
      * @param elementSize - size of the element in bytes
-     * @return - 0 for normal completion, 1 in case of unsuccessful completion,
-     * negative number in case errors
      * @see #fam_gather_indexed
      */
     void fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
@@ -663,8 +644,6 @@ class fam {
      * the strided access
      * @param stride - stride in elements
      * @param elementSize - size of each element in bytes
-     * @return - 0 for normal completion, 1 in case of unsuccessful completion,
-     * negative number in case errors
      * @see #fam_gather_strided
      */
     void fam_scatter_nonblocking(void *local, Fam_Descriptor *descriptor,
@@ -682,8 +661,6 @@ class fam {
      * @param nElements - number of elements to be scattered from local memory
      * @param elementIndex - array containing element indexes
      * @param elementSize - size of the element in bytes
-     * @return - 0 for normal completion, 1 in case of unsuccessful completion,
-     * negative number in case errors
      * @see #fam_gather_indexed
      */
     void fam_scatter_nonblocking(void *local, Fam_Descriptor *descriptor,

--- a/include/fam/fam.h
+++ b/include/fam/fam.h
@@ -277,7 +277,7 @@ class fam {
      * @see #fam_finalize()
      * @see #Fam_Options
      */
-    int fam_initialize(const char *groupName, Fam_Options *options);
+    void fam_initialize(const char *groupName, Fam_Options *options);
 
     /**
      * Finalize the fam library. Once finalized, the process can continue work,
@@ -381,7 +381,7 @@ class fam {
      * @see #fam_create_region
      * @see #fam_destroy_region
      */
-    int fam_resize_region(Fam_Region_Descriptor *descriptor, uint64_t nbytes);
+    void fam_resize_region(Fam_Region_Descriptor *descriptor, uint64_t nbytes);
 
     /**
      * Allocate some unnamed space within a region. Allocates an area of FAM
@@ -415,8 +415,8 @@ class fam {
      * @return - 0 on success, 1 for unsuccessful completion, negative number on
      * an exception
      */
-    int fam_change_permissions(Fam_Descriptor *descriptor,
-                               mode_t accessPermissions);
+    void fam_change_permissions(Fam_Descriptor *descriptor,
+                                mode_t accessPermissions);
 
     /**
      * Change permissions associated with a region descriptor.
@@ -425,8 +425,8 @@ class fam {
      * @return - 0 on success, 1 for unsuccessful completion, negative number on
      * an exception
      */
-    int fam_change_permissions(Fam_Region_Descriptor *descriptor,
-                               mode_t accessPermissions);
+    void fam_change_permissions(Fam_Region_Descriptor *descriptor,
+                                mode_t accessPermissions);
 
     /**
      * Get the size, permissions and name of the dataitem  associated
@@ -464,8 +464,8 @@ class fam {
      * @return - 0 for successful completion, 1 for unsuccessful, and a negative
      * number in case of exceptions
      */
-    int fam_get_blocking(void *local, Fam_Descriptor *descriptor,
-                         uint64_t offset, uint64_t nbytes);
+    void fam_get_blocking(void *local, Fam_Descriptor *descriptor,
+                          uint64_t offset, uint64_t nbytes);
 
     /**
      * Initiate a copy of data from FAM to node local memory. Do not wait until
@@ -491,8 +491,8 @@ class fam {
      * @return - 0 for successful completion, 1 for unsuccessful completion,
      * negative number in case of exceptions
      */
-    int fam_put_blocking(void *local, Fam_Descriptor *descriptor,
-                         uint64_t offset, uint64_t nbytes);
+    void fam_put_blocking(void *local, Fam_Descriptor *descriptor,
+                          uint64_t offset, uint64_t nbytes);
 
     /**
      * Initiate a copy of data from local memory to FAM, returning before copy
@@ -548,9 +548,9 @@ class fam {
      * negative number in case of exception
      * @see #fam_scatter_strided
      */
-    int fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
-                            uint64_t nElements, uint64_t firstElement,
-                            uint64_t stride, uint64_t elementSize);
+    void fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
+                             uint64_t nElements, uint64_t firstElement,
+                             uint64_t stride, uint64_t elementSize);
 
     /**
      * Gather data from FAM to local memory, blocking while copy is complete
@@ -568,9 +568,9 @@ class fam {
      * negative number in case errors
      * @see #fam_scatter_indexed
      */
-    int fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
-                            uint64_t nElements, uint64_t *elementIndex,
-                            uint64_t elementSize);
+    void fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
+                             uint64_t nElements, uint64_t *elementIndex,
+                             uint64_t elementSize);
 
     /**
      * Initiate a gather of data from FAM to local memory, return before
@@ -627,9 +627,9 @@ class fam {
      * negative number in case errors
      * @see #fam_gather_strided
      */
-    int fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
-                             uint64_t nElements, uint64_t firstElement,
-                             uint64_t stride, uint64_t elementSize);
+    void fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
+                              uint64_t nElements, uint64_t firstElement,
+                              uint64_t stride, uint64_t elementSize);
 
     /**
      * Scatter data from local memory to FAM.
@@ -646,9 +646,9 @@ class fam {
      * negative number in case errors
      * @see #fam_gather_indexed
      */
-    int fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
-                             uint64_t nElements, uint64_t *elementIndex,
-                             uint64_t elementSize);
+    void fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
+                              uint64_t nElements, uint64_t *elementIndex,
+                              uint64_t elementSize);
 
     /**
      * initiate a scatter data from local memory to FAM.

--- a/include/fam/fam.h
+++ b/include/fam/fam.h
@@ -273,6 +273,7 @@ class fam {
      * method called when a process uses the OpenFAM library.
      * @param groupName - name of the group of cooperating PEs.
      * @param options - options structure containing initialization choices
+     * @return - none
      * @see #fam_finalize()
      * @see #Fam_Options
      */
@@ -282,6 +283,7 @@ class fam {
      * Finalize the fam library. Once finalized, the process can continue work,
      * but it is disconnected from the OpenFAM library functions.
      * @param groupName - name of group of cooperating PEs for this job
+     * @return - none
      * @see #fam_initialize()
      */
     void fam_finalize(const char *groupName);
@@ -289,12 +291,14 @@ class fam {
     /**
      * Forcibly terminate all PEs in the same group as the caller
      * @param status - termination status to be returned by the program.
+     * @return - none
      */
     void fam_abort(int status);
 
     /**
      * Suspends the execution of the calling PE until all other PEs issue
      * a call to this particular fam_barrier_all() statement
+     * @return - none
      */
     void fam_barrier_all();
 
@@ -362,6 +366,7 @@ class fam {
      * method call will trigger a delayed free operation to permit other
      * instances currently using the region to finish.
      * @param descriptor - descriptor for the region
+     * @return - none
      * @see #fam_create_region
      * @see #fam_resize_region
      */
@@ -375,6 +380,7 @@ class fam {
      * @param descriptor - descriptor associated with the previously created
      * region
      * @param nbytes - new requested size of the allocated space
+     * @return - none
      * @see #fam_create_region
      * @see #fam_destroy_region
      */
@@ -401,6 +407,7 @@ class fam {
     /**
      * Deallocate allocated space in memory
      * @param descriptor - descriptor associated with the space.
+     * @return - none
      * @see #fam_allocate()
      */
     void fam_deallocate(Fam_Descriptor *descriptor);
@@ -409,6 +416,7 @@ class fam {
      * Change permissions associated with a data item descriptor.
      * @param descriptor - descriptor associated with some data item
      * @param accessPermissions - new permissions for the data item
+     * @return - none
      */
     void fam_change_permissions(Fam_Descriptor *descriptor,
                                 mode_t accessPermissions);
@@ -417,6 +425,7 @@ class fam {
      * Change permissions associated with a region descriptor.
      * @param descriptor - descriptor associated with some region
      * @param accessPermissions - new permissions for the region
+     * @return - none
      */
     void fam_change_permissions(Fam_Region_Descriptor *descriptor,
                                 mode_t accessPermissions);
@@ -454,6 +463,7 @@ class fam {
      * @param offset - byte offset within the space defined by the descriptor
      * from where memory should be copied
      * @param nbytes - number of bytes to be copied from global to local memory
+     * @return - none
      */
     void fam_get_blocking(void *local, Fam_Descriptor *descriptor,
                           uint64_t offset, uint64_t nbytes);
@@ -467,6 +477,7 @@ class fam {
      * @param offset - byte offset within the space defined by the descriptor
      * from where memory should be copied
      * @param nbytes - number of bytes to be copied from global to local memory
+     * @return - none
      */
     void fam_get_nonblocking(void *local, Fam_Descriptor *descriptor,
                              uint64_t offset, uint64_t nbytes);
@@ -479,6 +490,7 @@ class fam {
      * @param offset - byte offset within the region defined by the descriptor
      * to where data should be copied
      * @param nbytes - number of bytes to be copied from local to FAM
+     * @return - none
      */
     void fam_put_blocking(void *local, Fam_Descriptor *descriptor,
                           uint64_t offset, uint64_t nbytes);
@@ -492,6 +504,7 @@ class fam {
      * @param offset - byte offset within the region defined by the descriptor
      * to where data should be copied
      * @param nbytes - number of bytes to be copied from local to FAM
+     * @return - none
      */
     void fam_put_nonblocking(void *local, Fam_Descriptor *descriptor,
                              uint64_t offset, uint64_t nbytes);
@@ -513,6 +526,7 @@ class fam {
      * @param local - pointer within the process virtual address space to be
      * unmapped
      * @param descriptor - descriptor for the FAM to be unmapped
+     * @return - none
      * @see #fam_map()
      */
     void fam_unmap(void *local, Fam_Descriptor *descriptor);
@@ -533,6 +547,7 @@ class fam {
      * access
      * @param stride - stride in elements
      * @param elementSize - size of the element in bytes
+     * @return - none
      * @see #fam_scatter_strided
      */
     void fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
@@ -551,6 +566,7 @@ class fam {
      * @param nElements - number of elements to be gathered in local memory
      * @param elementIndex - array of element indexes in FAM to fetch
      * @param elementSize - size of each element in bytes
+     * @return - none
      * @see #fam_scatter_indexed
      */
     void fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
@@ -571,6 +587,7 @@ class fam {
      * access
      * @param stride - stride in elements
      * @param elementSize - size of the element in bytes
+     * @return - none
      * @see #fam_scatter_strided
      */
     void fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
@@ -589,6 +606,7 @@ class fam {
      * @param nElements - number of elements to be gathered in local memory
      * @param elementIndex - array of element indexes in FAM to fetch
      * @param elementSize - size of each element in bytes
+     * @return - none
      * @see #fam_scatter_indexed
      */
     void fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
@@ -608,6 +626,7 @@ class fam {
      * the strided access
      * @param stride - stride in elements
      * @param elementSize - size of each element in bytes
+     * @return - none
      * @see #fam_gather_strided
      */
     void fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
@@ -625,6 +644,7 @@ class fam {
      * @param nElements - number of elements to be scattered from local memory
      * @param elementIndex - array containing element indexes
      * @param elementSize - size of the element in bytes
+     * @return - none
      * @see #fam_gather_indexed
      */
     void fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
@@ -644,6 +664,7 @@ class fam {
      * the strided access
      * @param stride - stride in elements
      * @param elementSize - size of each element in bytes
+     * @return - none
      * @see #fam_gather_strided
      */
     void fam_scatter_nonblocking(void *local, Fam_Descriptor *descriptor,
@@ -661,6 +682,7 @@ class fam {
      * @param nElements - number of elements to be scattered from local memory
      * @param elementIndex - array containing element indexes
      * @param elementSize - size of the element in bytes
+     * @return - none
      * @see #fam_gather_indexed
      */
     void fam_scatter_nonblocking(void *local, Fam_Descriptor *descriptor,
@@ -679,6 +701,8 @@ class fam {
      * @param destOffset - byte offset within the space defined by the dest
      * descriptor to which memory should be copied.
      * @param nbytes - number of bytes to be copied
+     * @return - a pointer to the wait object for the copy operation
+     * @see #fam_copy_wait
      */
     void *fam_copy(Fam_Descriptor *src, uint64_t srcOffset,
                    Fam_Descriptor *dest, uint64_t destOffset, uint64_t nbytes);
@@ -686,6 +710,7 @@ class fam {
     /**
      * Wait for copy operation correspond to the wait object passed to complete
      * @param waitObj - unique tag to copy operation
+     * @return - none
      */
     void fam_copy_wait(void *waitObj);
     // ATOMICS Group
@@ -699,6 +724,7 @@ class fam {
      * @param offset - byte offset within the data item of the value to be
      * updated
      * @param value - value to be set at the given location
+     * @return - none
      */
     void fam_set(Fam_Descriptor *descriptor, uint64_t offset, int32_t value);
     void fam_set(Fam_Descriptor *descriptor, uint64_t offset, int64_t value);
@@ -716,6 +742,7 @@ class fam {
      * updated
      * @param value - value to be added to the existing value at the given
      * location
+     * @return - none
      */
     void fam_add(Fam_Descriptor *descriptor, uint64_t offset, int32_t value);
     void fam_add(Fam_Descriptor *descriptor, uint64_t offset, int64_t value);
@@ -732,6 +759,7 @@ class fam {
      * updated
      * @param value - value to be subtracted from the existing value at the
      * given location
+     * @return - none
      */
     void fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                       int32_t value);
@@ -753,6 +781,7 @@ class fam {
      * updated
      * @param value - value to be compared to the existing value at the given
      * location
+     * @return - none
      */
     void fam_min(Fam_Descriptor *descriptor, uint64_t offset, int32_t value);
     void fam_min(Fam_Descriptor *descriptor, uint64_t offset, int64_t value);
@@ -769,6 +798,7 @@ class fam {
      * updated
      * @param value - value to be compared to the existing value at the given
      * location
+     * @return - none
      */
     void fam_max(Fam_Descriptor *descriptor, uint64_t offset, int32_t value);
     void fam_max(Fam_Descriptor *descriptor, uint64_t offset, int64_t value);
@@ -785,6 +815,7 @@ class fam {
      * updated
      * @param value - value to be combined with the existing value at the given
      * location
+     * @return - none
      */
     void fam_and(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value);
     void fam_and(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value);
@@ -797,6 +828,7 @@ class fam {
      * updated
      * @param value - value to be combined with the existing value at the given
      * location
+     * @return - none
      */
     void fam_or(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value);
     void fam_or(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value);
@@ -809,6 +841,7 @@ class fam {
      * updated
      * @param value - value to be combined with the existing value at the given
      * location
+     * @return - none
      */
     void fam_xor(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value);
     void fam_xor(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value);
@@ -1028,6 +1061,7 @@ class fam {
      * operations issued by the calling thread after the fence Note that method
      * this does NOT order load/store accesses by the processor to FAM enabled
      * by fam_map().
+     * @return - none
      */
     void fam_fence(void);
 
@@ -1036,6 +1070,7 @@ class fam {
      * operations (put, scatter, atomics, copy) are completed. Note that method
      * this does NOT order or wait for completion of load/store accesses by the
      * processor to FAM enabled by fam_map().
+     * @return - none
      */
     void fam_quiet(void);
 

--- a/include/fam/fam_exception.h
+++ b/include/fam/fam_exception.h
@@ -79,47 +79,5 @@ class Fam_Exception : public std::exception {
     enum Fam_Error famErr;
 };
 
-class Fam_InvalidOption_Exception : public Fam_Exception {
-  public:
-    Fam_InvalidOption_Exception();
-    Fam_InvalidOption_Exception(const char *msg);
-};
-
-class Fam_Permission_Exception : public Fam_Exception {
-  public:
-    Fam_Permission_Exception();
-    Fam_Permission_Exception(const char *msg);
-};
-
-class Fam_Timeout_Exception : public Fam_Exception {
-  public:
-    Fam_Timeout_Exception();
-    Fam_Timeout_Exception(const char *msg);
-};
-
-class Fam_Datapath_Exception : public Fam_Exception {
-  public:
-    Fam_Datapath_Exception();
-    Fam_Datapath_Exception(const char *msg);
-    Fam_Datapath_Exception(enum Fam_Error fErr, const char *msg);
-};
-
-class Fam_Allocator_Exception : public Fam_Exception {
-  public:
-    Fam_Allocator_Exception();
-    Fam_Allocator_Exception(enum Fam_Error fErr, const char *msg);
-};
-
-class Fam_Pmi_Exception : public Fam_Exception {
-  public:
-    Fam_Pmi_Exception();
-    Fam_Pmi_Exception(const char *msg);
-};
-
-class Fam_Unimplemented_Exception : public Fam_Exception {
-  public:
-    Fam_Unimplemented_Exception();
-    Fam_Unimplemented_Exception(const char *msg);
-};
 } // namespace openfam
 #endif

--- a/src/common/fam_async_qhandler.cpp
+++ b/src/common/fam_async_qhandler.cpp
@@ -45,8 +45,10 @@
 #endif
 
 #include <iostream>
+#include <sstream>
 
 #include "common/fam_async_qhandler.h"
+#include "common/fam_internal.h"
 namespace openfam {
 
 class Fam_Async_QHandler::FamAsyncQHandlerImpl_ {
@@ -118,9 +120,12 @@ class Fam_Async_QHandler::FamAsyncQHandlerImpl_ {
             while (writeCQ->pop(err)) {
                 if (!(err->get_error_code()))
                     return;
-                else
+                else {
+                    std::ostringstream message;
+                    ERROR_MSG(message, err->get_error_msg());
                     throw Fam_Datapath_Exception(err->get_error_code(),
-                                                 err->get_error_msg());
+                                                 message.str().c_str());
+                }
             }
         }
     }
@@ -138,9 +143,12 @@ class Fam_Async_QHandler::FamAsyncQHandlerImpl_ {
             while (readCQ->pop(err)) {
                 if (!(err->get_error_code()))
                     return;
-                else
+                else {
+                    std::ostringstream message;
+                    ERROR_MSG(message, err->get_error_msg());
                     throw Fam_Datapath_Exception(err->get_error_code(),
-                                                 err->get_error_msg());
+                                                 message.str().c_str());
+                }
             }
         }
     }
@@ -176,8 +184,10 @@ class Fam_Async_QHandler::FamAsyncQHandlerImpl_ {
             break;
         }
         default: {
+            std::ostringstream message;
+            ERROR_MSG(message, "invalid operation request");
             throw Fam_Datapath_Exception(FAM_ERR_INVALIDOP,
-                                         "invalid operation request");
+                                         message.str().c_str());
         }
         }
         return;

--- a/src/common/fam_async_qhandler.cpp
+++ b/src/common/fam_async_qhandler.cpp
@@ -45,7 +45,6 @@
 #endif
 
 #include <iostream>
-#include <sstream>
 
 #include "common/fam_async_qhandler.h"
 #include "common/fam_internal.h"
@@ -120,12 +119,10 @@ class Fam_Async_QHandler::FamAsyncQHandlerImpl_ {
             while (writeCQ->pop(err)) {
                 if (!(err->get_error_code()))
                     return;
-                else {
-                    std::ostringstream message;
-                    ERROR_MSG(message, err->get_error_msg());
-                    throw Fam_Datapath_Exception(err->get_error_code(),
-                                                 message.str().c_str());
-                }
+                else
+                    THROW_ERRNO_MSG(Fam_Datapath_Exception,
+                                    err->get_error_code(),
+                                    err->get_error_msg());
             }
         }
     }
@@ -143,12 +140,10 @@ class Fam_Async_QHandler::FamAsyncQHandlerImpl_ {
             while (readCQ->pop(err)) {
                 if (!(err->get_error_code()))
                     return;
-                else {
-                    std::ostringstream message;
-                    ERROR_MSG(message, err->get_error_msg());
-                    throw Fam_Datapath_Exception(err->get_error_code(),
-                                                 message.str().c_str());
-                }
+                else
+                    THROW_ERRNO_MSG(Fam_Datapath_Exception,
+                                    err->get_error_code(),
+                                    err->get_error_msg());
             }
         }
     }
@@ -184,10 +179,8 @@ class Fam_Async_QHandler::FamAsyncQHandlerImpl_ {
             break;
         }
         default: {
-            std::ostringstream message;
-            ERROR_MSG(message, "invalid operation request");
-            throw Fam_Datapath_Exception(FAM_ERR_INVALIDOP,
-                                         message.str().c_str());
+            THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_INVALIDOP,
+                            "invalid operation request");
         }
         }
         return;

--- a/src/common/fam_exception.cpp
+++ b/src/common/fam_exception.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "fam/fam_exception.h"
+#include "common/fam_internal.h"
 namespace openfam {
 
 Fam_Exception::Fam_Exception() : Fam_Exception("Unknown error") {}

--- a/src/common/fam_internal.h
+++ b/src/common/fam_internal.h
@@ -185,18 +185,20 @@ inline void openfam_invalidate(void *addr, uint64_t size) {
  * Fam_Exception objects.
  *
  */
-template <typename T> void log_msg(std::ostringstream &message, T const &f) {
-    message << f;
-}
 
-template <typename T, typename... Args>
-void log_msg(std::ostringstream &message, T const &f, Args const &... args) {
-    message << f << ":";
-    log_msg(message, args...);
-}
+#define THROW_ERR_MSG(exception, message_str)                                  \
+    do {                                                                       \
+        std::ostringstream errMsgStr;                                          \
+        errMsgStr << __func__ << ":" << __LINE__ << ":" << message_str;        \
+        throw exception(errMsgStr.str().c_str());                              \
+    } while (0)
 
-#define ERROR_MSG(message, ...)                                                \
-    log_msg(message, __func__, __LINE__, __VA_ARGS__)
+#define THROW_ERRNO_MSG(exception, error_no, message_str)                      \
+    do {                                                                       \
+        std::ostringstream errMsgStr;                                          \
+        errMsgStr << __func__ << ":" << __LINE__ << ":" << message_str;        \
+        throw exception(error_no, errMsgStr.str().c_str());                    \
+    } while (0)
 
 class Fam_InvalidOption_Exception : public Fam_Exception {
   public:

--- a/src/common/fam_internal.h
+++ b/src/common/fam_internal.h
@@ -75,6 +75,7 @@
 
 #include "nvmm/epoch_manager.h"
 #include "nvmm/memory_manager.h"
+#include "fam/fam_exception.h"
 #include <nvmm/fam.h>
 
 using namespace famradixtree;
@@ -177,6 +178,68 @@ inline void openfam_invalidate(void *addr, uint64_t size) {
     fam_invalidate(addr, size);
 #endif
 }
+
+/*
+ * These derived exception classes are currently being used
+ * internally by OpenFAM. All the OpenFAM api return only
+ * Fam_Exception objects.
+ *
+ */
+template <typename T> void log_msg(std::ostringstream &message, T const &f) {
+    message << f;
+}
+
+template <typename T, typename... Args>
+void log_msg(std::ostringstream &message, T const &f, Args const &... args) {
+    message << f << ":";
+    log_msg(message, args...);
+}
+
+#define ERROR_MSG(message, ...)                                                \
+    log_msg(message, __func__, __LINE__, __VA_ARGS__)
+
+class Fam_InvalidOption_Exception : public Fam_Exception {
+  public:
+    Fam_InvalidOption_Exception();
+    Fam_InvalidOption_Exception(const char *msg);
+};
+
+class Fam_Permission_Exception : public Fam_Exception {
+  public:
+    Fam_Permission_Exception();
+    Fam_Permission_Exception(const char *msg);
+};
+
+class Fam_Timeout_Exception : public Fam_Exception {
+  public:
+    Fam_Timeout_Exception();
+    Fam_Timeout_Exception(const char *msg);
+};
+
+class Fam_Datapath_Exception : public Fam_Exception {
+  public:
+    Fam_Datapath_Exception();
+    Fam_Datapath_Exception(const char *msg);
+    Fam_Datapath_Exception(enum Fam_Error fErr, const char *msg);
+};
+
+class Fam_Allocator_Exception : public Fam_Exception {
+  public:
+    Fam_Allocator_Exception();
+    Fam_Allocator_Exception(enum Fam_Error fErr, const char *msg);
+};
+
+class Fam_Pmi_Exception : public Fam_Exception {
+  public:
+    Fam_Pmi_Exception();
+    Fam_Pmi_Exception(const char *msg);
+};
+
+class Fam_Unimplemented_Exception : public Fam_Exception {
+  public:
+    Fam_Unimplemented_Exception();
+    Fam_Unimplemented_Exception(const char *msg);
+};
 
 } // namespace openfam
 

--- a/src/common/fam_internal_exception.cpp
+++ b/src/common/fam_internal_exception.cpp
@@ -1,5 +1,5 @@
 /*
- * fam_exception.cpp
+ * fam_internal_exception.cpp
  * Copyright (c) 2019 Hewlett Packard Enterprise Development, LP. All rights
  * reserved. Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/common/fam_libfabric.cpp
+++ b/src/common/fam_libfabric.cpp
@@ -553,7 +553,7 @@ int fabric_deregister_mr(fid_mr *&mr) {
 }
 
 int fabric_retry(Fam_Context *famCtx, ssize_t ret, uint32_t *retry_cnt) {
-    std::ostringstream message;
+
     if (ret) {
         if (ret == -FI_EAGAIN) {
             struct fi_cq_err_entry err;
@@ -561,23 +561,21 @@ int fabric_retry(Fam_Context *famCtx, ssize_t ret, uint32_t *retry_cnt) {
             if (ret == 1) {
                 const char *errmsg = fi_cq_strerror(
                     famCtx->get_txcq(), err.prov_errno, err.err_data, NULL, 0);
-                ERROR_MSG(message, errmsg);
-                throw Fam_Datapath_Exception(message.str().c_str());
+                THROW_ERR_MSG(Fam_Datapath_Exception, errmsg);
             } else if (ret && ret != -FI_EAGAIN) {
-                ERROR_MSG(message, "Reading from fabric CQ failed");
-                throw Fam_Datapath_Exception(message.str().c_str());
+                THROW_ERR_MSG(Fam_Datapath_Exception,
+                              "Reading from fabric CQ failed");
             }
 
             (*retry_cnt)++;
             if ((*retry_cnt) <= MAX_RETRY_CNT) {
                 return 1;
             } else {
-                ERROR_MSG(message, "Fabric max retry count exceeded");
-                throw Fam_Datapath_Exception(message.str().c_str());
+                THROW_ERR_MSG(Fam_Timeout_Exception,
+                              "Fabric max retry count exceeded");
             }
         } else {
-            ERROR_MSG(message, fabric_strerror((int)ret));
-            throw Fam_Datapath_Exception(message.str().c_str());
+            THROW_ERR_MSG(Fam_Datapath_Exception, fabric_strerror((int)ret));
         }
     }
 
@@ -591,7 +589,6 @@ int fabric_completion_wait(Fam_Context *famCtx, fi_context *ctx) {
     int timeout_retry_cnt = 0;
     int timeout_wait_retry_cnt = 0;
     uint64_t success, failure, reqcnt;
-    std::ostringstream message;
     do {
         success = (uint64_t)ctx->internal[0];
         failure = (uint64_t)ctx->internal[1];
@@ -608,9 +605,7 @@ int fabric_completion_wait(Fam_Context *famCtx, fi_context *ctx) {
             int err = errptr->err;
             free(ctx->internal[3]);
 
-            ERROR_MSG(message, errmsg);
-            throw Fam_Datapath_Exception(get_fam_error(err),
-                                         message.str().c_str());
+            THROW_ERRNO_MSG(Fam_Datapath_Exception, get_fam_error(err), errmsg);
         }
 
         memset(&entry, 0, sizeof(entry));
@@ -633,9 +628,9 @@ int fabric_completion_wait(Fam_Context *famCtx, fi_context *ctx) {
                 usleep(FABRIC_TIMEOUT * 1000);
                 continue;
             } else {
-                ERROR_MSG(message,
-                          "fi_cq_read timeout retry count exceeded INT_MAX");
-                throw Fam_Timeout_Exception(message.str().c_str());
+                THROW_ERR_MSG(
+                    Fam_Timeout_Exception,
+                    "fi_cq_read timeout retry count exceeded INT_MAX");
             }
         }
         if (ret < 0) {
@@ -650,9 +645,9 @@ int fabric_completion_wait(Fam_Context *famCtx, fi_context *ctx) {
                         (uint64_t *)&((fi_context *)err.op_context)
                             ->internal[1],
                         one);
-                    ERROR_MSG(message, errmsg);
-                    throw Fam_Datapath_Exception(get_fam_error(err.err),
-                                                 message.str().c_str());
+
+                    THROW_ERRNO_MSG(Fam_Datapath_Exception,
+                                    get_fam_error(err.err), errmsg);
                 } else {
                     if ((fi_context *)err.op_context != NULL) {
                         __sync_fetch_and_add(
@@ -673,8 +668,8 @@ int fabric_completion_wait(Fam_Context *famCtx, fi_context *ctx) {
                 }
 
             } else if (ret && ret != -FI_EAGAIN) {
-                ERROR_MSG(message, "Reading from fabric CQ failed");
-                throw Fam_Datapath_Exception(message.str().c_str());
+                THROW_ERR_MSG(Fam_Datapath_Exception,
+                              "Reading from fabric CQ failed");
             }
         }
     } while (success < reqcnt);
@@ -1436,7 +1431,6 @@ void fabric_put_quiet(Fam_Context *famCtx) {
     ssize_t ret = 0;
     uint64_t txLastFailCnt = famCtx->get_num_tx_fail_cnt();
     int timeout_wait_retry_cnt = 0;
-    std::ostringstream message;
 
     txcnt = famCtx->get_num_tx_ops();
     do {
@@ -1457,9 +1451,8 @@ void fabric_put_quiet(Fam_Context *famCtx) {
                         fi_cq_strerror(famCtx->get_txcq(), err.prov_errno,
                                        err.err_data, NULL, 0);
                     famCtx->inc_num_tx_fail_cnt(txfail - txLastFailCnt);
-                    ERROR_MSG(message, errmsg);
-                    throw Fam_Datapath_Exception(get_fam_error(err.err),
-                                                 message.str().c_str());
+                    THROW_ERRNO_MSG(Fam_Datapath_Exception,
+                                    get_fam_error(err.err), errmsg);
                 }
             } while (ret < 0 &&
                      ((ret == -FI_EAGAIN) || (ret == -FI_ETIMEDOUT)));
@@ -1471,8 +1464,8 @@ void fabric_put_quiet(Fam_Context *famCtx) {
             timeout_wait_retry_cnt++;
             usleep(FABRIC_TIMEOUT * 1000);
         } else {
-            ERROR_MSG(message, "Timeout retry count exceeded INT_MAX");
-            throw Fam_Timeout_Exception(message.str().c_str());
+            THROW_ERR_MSG(Fam_Timeout_Exception,
+                          "Timeout retry count exceeded INT_MAX");
         }
     } while ((txsuccess + txfail) < txcnt);
 
@@ -1491,7 +1484,6 @@ void fabric_get_quiet(Fam_Context *famCtx) {
     uint64_t rxLastFailCnt = famCtx->get_num_rx_fail_cnt();
     int timeout_wait_retry_cnt = 0;
     rxcnt = famCtx->get_num_rx_ops();
-    std::ostringstream message;
 
     do {
 
@@ -1513,9 +1505,8 @@ void fabric_get_quiet(Fam_Context *famCtx) {
                         fi_cq_strerror(famCtx->get_txcq(), err.prov_errno,
                                        err.err_data, NULL, 0);
                     famCtx->inc_num_rx_fail_cnt(rxfail - rxLastFailCnt);
-                    ERROR_MSG(message, errmsg);
-                    throw Fam_Datapath_Exception(get_fam_error(err.err),
-                                                 message.str().c_str());
+                    THROW_ERRNO_MSG(Fam_Datapath_Exception,
+                                    get_fam_error(err.err), errmsg);
                 }
             } while (ret < 0 &&
                      ((ret == -FI_EAGAIN) || (ret == -FI_ETIMEDOUT)));
@@ -1527,8 +1518,8 @@ void fabric_get_quiet(Fam_Context *famCtx) {
             timeout_wait_retry_cnt++;
             usleep(FABRIC_TIMEOUT * 1000);
         } else {
-            ERROR_MSG(message, "Timeout retry count exceeded INT_MAX");
-            throw Fam_Timeout_Exception(message.str().c_str());
+            THROW_ERR_MSG(Fam_Timeout_Exception,
+                          "Timeout retry count exceeded INT_MAX");
         }
     } while ((rxsuccess + rxfail) < rxcnt);
 

--- a/src/common/fam_libfabric.h
+++ b/src/common/fam_libfabric.h
@@ -53,6 +53,7 @@
 
 #include "cis/fam_cis_rpc.grpc.pb.h"
 #include "common/fam_context.h"
+#include "common/fam_internal.h"
 #include "common/fam_options.h"
 #include "fam/fam_exception.h"
 

--- a/src/common/fam_ops_libfabric.h
+++ b/src/common/fam_ops_libfabric.h
@@ -32,7 +32,6 @@
 
 #include <iostream>
 #include <map>
-#include <sstream>
 #include <string.h>
 #include <sys/uio.h>
 #include <thread>
@@ -326,29 +325,26 @@ class Fam_Ops_Libfabric : public Fam_Ops {
     std::map<uint64_t, Fam_Region_Map_t *> *get_fiMrs() { return fiMrs; };
     Fam_Context *get_defaultCtx(uint64_t nodeId) {
         auto obj = defContexts->find(nodeId);
-        if (obj == defContexts->end()) {
-            std::ostringstream message;
-            ERROR_MSG(message, "Context for memserver not found");
-            throw Fam_Datapath_Exception(message.str().c_str());
-        } else
+        if (obj == defContexts->end())
+            THROW_ERR_MSG(Fam_Datapath_Exception,
+                          "Context for memserver not found");
+        else
             return obj->second;
     }
     Fam_Context *get_defaultCtx(Fam_Region_Descriptor *descriptor) {
         auto obj = defContexts->find(descriptor->get_memserver_id());
-        if (obj == defContexts->end()) {
-            std::ostringstream message;
-            ERROR_MSG(message, "Context for memserver not found");
-            throw Fam_Datapath_Exception(message.str().c_str());
-        } else
+        if (obj == defContexts->end())
+            THROW_ERR_MSG(Fam_Datapath_Exception,
+                          "Context for memserver not found");
+        else
             return obj->second;
     };
     Fam_Context *get_defaultCtx(Fam_Descriptor *descriptor) {
         auto obj = defContexts->find(descriptor->get_memserver_id());
-        if (obj == defContexts->end()) {
-            std::ostringstream message;
-            ERROR_MSG(message, "Context for memserver not found");
-            throw Fam_Datapath_Exception(message.str().c_str());
-        } else
+        if (obj == defContexts->end())
+            THROW_ERR_MSG(Fam_Datapath_Exception,
+                          "Context for memserver not found");
+        else
             return obj->second;
     };
     pthread_rwlock_t *get_mr_lock() { return &fiMrLock; };

--- a/src/common/fam_ops_libfabric.h
+++ b/src/common/fam_ops_libfabric.h
@@ -32,6 +32,7 @@
 
 #include <iostream>
 #include <map>
+#include <sstream>
 #include <string.h>
 #include <sys/uio.h>
 #include <thread>
@@ -48,6 +49,7 @@
 
 #include "allocator/fam_allocator_client.h"
 #include "common/fam_context.h"
+#include "common/fam_internal.h"
 #include "common/fam_ops.h"
 #include "common/fam_options.h"
 #include "fam/fam.h"
@@ -324,23 +326,29 @@ class Fam_Ops_Libfabric : public Fam_Ops {
     std::map<uint64_t, Fam_Region_Map_t *> *get_fiMrs() { return fiMrs; };
     Fam_Context *get_defaultCtx(uint64_t nodeId) {
         auto obj = defContexts->find(nodeId);
-        if (obj == defContexts->end())
-            throw Fam_Datapath_Exception("Context for memserver not found");
-        else
+        if (obj == defContexts->end()) {
+            std::ostringstream message;
+            ERROR_MSG(message, "Context for memserver not found");
+            throw Fam_Datapath_Exception(message.str().c_str());
+        } else
             return obj->second;
     }
     Fam_Context *get_defaultCtx(Fam_Region_Descriptor *descriptor) {
         auto obj = defContexts->find(descriptor->get_memserver_id());
-        if (obj == defContexts->end())
-            throw Fam_Datapath_Exception("Context for memserver not found");
-        else
+        if (obj == defContexts->end()) {
+            std::ostringstream message;
+            ERROR_MSG(message, "Context for memserver not found");
+            throw Fam_Datapath_Exception(message.str().c_str());
+        } else
             return obj->second;
     };
     Fam_Context *get_defaultCtx(Fam_Descriptor *descriptor) {
         auto obj = defContexts->find(descriptor->get_memserver_id());
-        if (obj == defContexts->end())
-            throw Fam_Datapath_Exception("Context for memserver not found");
-        else
+        if (obj == defContexts->end()) {
+            std::ostringstream message;
+            ERROR_MSG(message, "Context for memserver not found");
+            throw Fam_Datapath_Exception(message.str().c_str());
+        } else
             return obj->second;
     };
     pthread_rwlock_t *get_mr_lock() { return &fiMrLock; };

--- a/src/fam-api/fam.cpp
+++ b/src/fam-api/fam.cpp
@@ -34,6 +34,7 @@
 #include <unistd.h>
 
 #include "allocator/fam_allocator_client.h"
+#include "common/fam_internal.h"
 #include "common/fam_libfabric.h"
 #include "common/fam_ops.h"
 #include "common/fam_ops_libfabric.h"
@@ -47,6 +48,16 @@
 #ifdef FAM_PROFILE
 #include "fam_counters.h"
 #endif
+
+// Add this wrapper try catch block to return only Fam_Exception object
+// instead of derived exception class objects, to maintain uniformity in
+// exception handling by the application.
+#define TRY_CATCH_BEGIN try {
+#define RETURN_WITH_FAM_EXCEPTION                                              \
+    }                                                                          \
+    catch (Fam_Exception & e) {                                                \
+        throw e;                                                               \
+    }
 
 using namespace std;
 
@@ -100,7 +111,7 @@ class fam::Impl_ {
             delete famRuntime;
     }
 
-    int fam_initialize(const char *groupName, Fam_Options *options);
+    void fam_initialize(const char *groupName, Fam_Options *options);
 
     void fam_finalize(const char *groupName);
 
@@ -122,7 +133,7 @@ class fam::Impl_ {
 
     void fam_destroy_region(Fam_Region_Descriptor *descriptor);
 
-    int fam_resize_region(Fam_Region_Descriptor *descriptor, uint64_t nbytes);
+    void fam_resize_region(Fam_Region_Descriptor *descriptor, uint64_t nbytes);
 
     Fam_Descriptor *fam_allocate(uint64_t nbytes, mode_t accessPermissions,
                                  Fam_Region_Descriptor *region);
@@ -132,23 +143,23 @@ class fam::Impl_ {
 
     void fam_deallocate(Fam_Descriptor *descriptor);
 
-    int fam_change_permissions(Fam_Descriptor *descriptor,
-                               mode_t accessPermissions);
+    void fam_change_permissions(Fam_Descriptor *descriptor,
+                                mode_t accessPermissions);
 
-    int fam_change_permissions(Fam_Region_Descriptor *descriptor,
-                               mode_t accessPermissions);
+    void fam_change_permissions(Fam_Region_Descriptor *descriptor,
+                                mode_t accessPermissions);
 
     void fam_stat(Fam_Descriptor *descriptor, Fam_Stat *famInfo);
     void fam_stat(Fam_Region_Descriptor *descriptor, Fam_Stat *famInfo);
 
-    int fam_get_blocking(void *local, Fam_Descriptor *descriptor,
-                         uint64_t offset, uint64_t nbytes);
+    void fam_get_blocking(void *local, Fam_Descriptor *descriptor,
+                          uint64_t offset, uint64_t nbytes);
 
     void fam_get_nonblocking(void *local, Fam_Descriptor *descriptor,
                              uint64_t offset, uint64_t nbytes);
 
-    int fam_put_blocking(void *local, Fam_Descriptor *descriptor,
-                         uint64_t offset, uint64_t nbytes);
+    void fam_put_blocking(void *local, Fam_Descriptor *descriptor,
+                          uint64_t offset, uint64_t nbytes);
 
     void fam_put_nonblocking(void *local, Fam_Descriptor *descriptor,
                              uint64_t offset, uint64_t nbytes);
@@ -157,13 +168,13 @@ class fam::Impl_ {
 
     void fam_unmap(void *local, Fam_Descriptor *descriptor);
 
-    int fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
-                            uint64_t nElements, uint64_t firstElement,
-                            uint64_t stride, uint64_t elementSize);
+    void fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
+                             uint64_t nElements, uint64_t firstElement,
+                             uint64_t stride, uint64_t elementSize);
 
-    int fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
-                            uint64_t nElements, uint64_t *elementIndex,
-                            uint64_t elementSize);
+    void fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
+                             uint64_t nElements, uint64_t *elementIndex,
+                             uint64_t elementSize);
 
     void fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
                                 uint64_t nElements, uint64_t firstElement,
@@ -173,13 +184,13 @@ class fam::Impl_ {
                                 uint64_t nElements, uint64_t *elementIndex,
                                 uint64_t elementSize);
 
-    int fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
-                             uint64_t nElements, uint64_t firstElement,
-                             uint64_t stride, uint64_t elementSize);
+    void fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
+                              uint64_t nElements, uint64_t firstElement,
+                              uint64_t stride, uint64_t elementSize);
 
-    int fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
-                             uint64_t nElements, uint64_t *elementIndex,
-                             uint64_t elementSize);
+    void fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
+                              uint64_t nElements, uint64_t *elementIndex,
+                              uint64_t elementSize);
 
     void fam_scatter_nonblocking(void *local, Fam_Descriptor *descriptor,
                                  uint64_t nElements, uint64_t firstElement,
@@ -577,7 +588,7 @@ class fam::Impl_ {
  * @see #fam_finalize()
  * @see #Fam_Options
  */
-int fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
+void fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
     std::ostringstream message;
     int ret = 0;
     int *peCnt;
@@ -589,7 +600,7 @@ int fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
     if (grpName)
         groupName = strdup(grpName);
     else {
-        message << "Fam Invalid Option specified: GroupName";
+        ERROR_MSG(message, "Fam Invalid Option specified: GroupName");
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
     // Initialize Options
@@ -600,9 +611,8 @@ int fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
 
     memoryServerCount = 1;
 
-    if ((ret = validate_fam_options(options)) < 0) {
-        return ret;
-    }
+    ret = validate_fam_options(options);
+
     if (strcmp(famOptions.runtime, FAM_OPTIONS_RUNTIME_NONE_STR) == 0) {
         *peId = 0;
         *peCnt = 1;
@@ -615,7 +625,8 @@ int fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
             famRuntime = new Pmi2_Runtime();
             if (PMI2_SUCCESS != (ret = famRuntime->runtime_init())) {
                 // Raising an exception will make the use of pmix mandatory.
-                message << "Fam PMI2 Runtime initialization failed: " << ret;
+                ERROR_MSG(message, "Fam PMI2 Runtime initialization failed",
+                          ret);
                 throw Fam_Pmi_Exception(message.str().c_str());
             }
         } else {
@@ -623,7 +634,8 @@ int fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
             famRuntime = new Pmix_Runtime();
             if (PMIX_SUCCESS != (ret = famRuntime->runtime_init())) {
                 // Raising an exception will make the use of pmix mandatory.
-                message << "Fam PMIx Runtime initialization failed: " << ret;
+                ERROR_MSG(message, "Fam PMIx Runtime initialization failed",
+                          ret);
                 throw Fam_Pmi_Exception(message.str().c_str());
             }
         }
@@ -631,14 +643,14 @@ int fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
 
         *peCnt = famRuntime->num_pes();
         if (*peCnt < 0) {
-            message << "PMIx Runtime Failed to get PE_COUNT: " << *peCnt;
+            ERROR_MSG(message, "PMIx Runtime Failed to get PE_COUNT", *peCnt);
             free(peCnt);
             throw Fam_Exception(message.str().c_str());
         }
 
         *peId = famRuntime->my_pe();
         if (*peId < 0) {
-            message << "PMIx Runtime Failed to get PE_ID: " << *peId;
+            ERROR_MSG(message, "PMIx Runtime Failed to get PE_ID", *peId);
             free(peCnt);
             free(peId);
             throw Fam_Exception(message.str().c_str());
@@ -665,7 +677,8 @@ int fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
             parse_memserver_list(memoryServer, delimiter1, delimiter2);
 
         if (memoryServerList.size() == 0) {
-            throw Fam_InvalidOption_Exception("Memory server list not found");
+            ERROR_MSG(message, "Memory server list not found");
+            throw Fam_InvalidOption_Exception(message.str().c_str());
         }
 
         memoryServerCount = memoryServerList.size();
@@ -673,9 +686,9 @@ int fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
         for (auto it = memoryServerList.begin(); it != memoryServerList.end();
              ++it) {
             if (it->first >= memoryServerCount) {
-                message << "Fam Invalid memory server ID specified: "
-                        << it->first
-                        << " should be less than memory server count";
+                ERROR_MSG(message, "Fam Invalid memory server ID specified ",
+                          it->first,
+                          " should be less than memory server count");
                 throw Fam_InvalidOption_Exception(message.str().c_str());
             }
         }
@@ -688,15 +701,14 @@ int fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
 
         ret = famOps->initialize();
         if (ret < 0) {
-            message << "Fam libfabric initialization failed: "
-                    << fabric_strerror(ret);
+            ERROR_MSG(message, "Fam libfabric initialization failed",
+                      fabric_strerror(ret));
             if (famRuntime != NULL)
                 famRuntime->runtime_fini();
             throw Fam_Datapath_Exception(message.str().c_str());
         }
     }
     FAM_PROFILE_START_TIME();
-    return ret;
 }
 
 /**
@@ -756,8 +768,8 @@ int fam::Impl_::validate_fam_options(Fam_Options *options) {
     else if (strcmp(famOptions.famThreadModel, FAM_THREAD_MULTIPLE_STR) == 0)
         famThreadModel = FAM_THREAD_MULTIPLE;
     else {
-        message << "Invalid value specified for famThreadModel: "
-                << famOptions.famThreadModel;
+        ERROR_MSG(message, "Invalid value specified for famThreadModel",
+                  famOptions.famThreadModel);
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
     optValueMap->insert(
@@ -770,8 +782,8 @@ int fam::Impl_::validate_fam_options(Fam_Options *options) {
 
     if ((strcmp(famOptions.allocator, FAM_OPTIONS_SHM_STR) != 0) &&
         (strcmp(famOptions.allocator, FAM_OPTIONS_GRPC_STR) != 0)) {
-        message << "Invalid value specified for Allocator: "
-                << famOptions.famThreadModel;
+        ERROR_MSG(message, "Invalid value specified for Allocator",
+                  famOptions.famThreadModel);
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
@@ -787,8 +799,8 @@ int fam::Impl_::validate_fam_options(Fam_Options *options) {
     else if (strcmp(famOptions.famContextModel, FAM_CONTEXT_REGION_STR) == 0)
         famContextModel = FAM_CONTEXT_REGION;
     else {
-        message << "Invalid value specified for famContextModel: "
-                << famOptions.famContextModel;
+        ERROR_MSG(message, "Invalid value specified for famContextModel",
+                  famOptions.famContextModel);
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
     optValueMap->insert(
@@ -801,8 +813,8 @@ int fam::Impl_::validate_fam_options(Fam_Options *options) {
     if ((strcmp(famOptions.runtime, FAM_OPTIONS_RUNTIME_PMI2_STR) != 0) &&
         (strcmp(famOptions.runtime, FAM_OPTIONS_RUNTIME_NONE_STR) != 0) &&
         (strcmp(famOptions.runtime, FAM_OPTIONS_RUNTIME_PMIX_STR) != 0)) {
-        message << "Invalid value specified for Runtime: "
-                << famOptions.runtime;
+        ERROR_MSG(message, "Invalid value specified for Runtime",
+                  famOptions.runtime);
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
     optValueMap->insert({supportedOptionList[RUNTIME], famOptions.runtime});
@@ -848,7 +860,7 @@ int fam::Impl_::validate_item(Fam_Descriptor *descriptor) {
     }
 
     if (key == FAM_KEY_INVALID) {
-        message << "Invalid Key Passed" << endl;
+        ERROR_MSG(message, "Invalid Key Passed");
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
     return 0;
@@ -937,7 +949,7 @@ const void *fam::Impl_::fam_get_option(char *optionName) {
     auto opt = optValueMap->find(optionName);
     if (opt == optValueMap->end()) {
         std::ostringstream message;
-        message << "Fam Option not supported: " << optionName;
+        ERROR_MSG(message, "Fam Option not supported", optionName);
         throw Fam_InvalidOption_Exception(message.str().c_str());
     } else {
         if (strncmp(optionName, "PE", 2) == 0) {
@@ -1052,13 +1064,12 @@ void fam::Impl_::fam_destroy_region(Fam_Region_Descriptor *descriptor) {
  * @see #fam_create_region
  * @see #fam_destroy_region
  */
-int fam::Impl_::fam_resize_region(Fam_Region_Descriptor *descriptor,
-                                  uint64_t nbytes) {
+void fam::Impl_::fam_resize_region(Fam_Region_Descriptor *descriptor,
+                                   uint64_t nbytes) {
     FAM_CNTR_INC_API(fam_resize_region);
     FAM_PROFILE_START_ALLOCATOR(fam_resize_region);
     famAllocator->resize_region(descriptor, nbytes);
     FAM_PROFILE_END_ALLOCATOR(fam_resize_region);
-    return 0;
 }
 
 /**
@@ -1112,13 +1123,12 @@ void fam::Impl_::fam_deallocate(Fam_Descriptor *descriptor) {
  * @return - 0 on success, 1 for unsuccessful completion, negative number on an
  * exception
  */
-int fam::Impl_::fam_change_permissions(Fam_Descriptor *descriptor,
-                                       mode_t accessPermissions) {
+void fam::Impl_::fam_change_permissions(Fam_Descriptor *descriptor,
+                                        mode_t accessPermissions) {
     FAM_CNTR_INC_API(fam_change_permissions);
     FAM_PROFILE_START_ALLOCATOR(fam_change_permissions);
     famAllocator->change_permission(descriptor, accessPermissions);
     FAM_PROFILE_END_ALLOCATOR(fam_change_permissions);
-    return 0;
 }
 
 /**
@@ -1128,13 +1138,12 @@ int fam::Impl_::fam_change_permissions(Fam_Descriptor *descriptor,
  * @return - 0 on success, 1 for unsuccessful completion, negative number on an
  * exception
  */
-int fam::Impl_::fam_change_permissions(Fam_Region_Descriptor *descriptor,
-                                       mode_t accessPermissions) {
+void fam::Impl_::fam_change_permissions(Fam_Region_Descriptor *descriptor,
+                                        mode_t accessPermissions) {
     FAM_CNTR_INC_API(fam_change_permissions);
     FAM_PROFILE_START_ALLOCATOR(fam_change_permissions);
     famAllocator->change_permission(descriptor, accessPermissions);
     FAM_PROFILE_END_ALLOCATOR(fam_change_permissions);
-    return 0;
 }
 
 /**
@@ -1211,7 +1220,9 @@ void *fam::Impl_::fam_map(Fam_Descriptor *descriptor) {
     FAM_CNTR_INC_API(fam_map);
     FAM_PROFILE_START_ALLOCATOR(fam_map);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
     int ret = validate_item(descriptor);
     FAM_PROFILE_END_ALLOCATOR(fam_map);
@@ -1240,7 +1251,9 @@ void fam::Impl_::fam_unmap(void *local, Fam_Descriptor *descriptor) {
     FAM_CNTR_INC_API(fam_unmap);
     FAM_PROFILE_START_ALLOCATOR(fam_unmap);
     if (descriptor == NULL || local == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1273,8 +1286,8 @@ void fam::Impl_::fam_unmap(void *local, Fam_Descriptor *descriptor) {
  * @throws : Fam_Permission_Exception if the given key has incorrect permissions
  * @throws : Fam_Datapath_Exception if libfabric read fails
  */
-int fam::Impl_::fam_get_blocking(void *local, Fam_Descriptor *descriptor,
-                                 uint64_t offset, uint64_t nbytes) {
+void fam::Impl_::fam_get_blocking(void *local, Fam_Descriptor *descriptor,
+                                  uint64_t offset, uint64_t nbytes) {
 
     int ret = 0;
     std::ostringstream message;
@@ -1282,7 +1295,8 @@ int fam::Impl_::fam_get_blocking(void *local, Fam_Descriptor *descriptor,
     FAM_CNTR_INC_API(fam_get_blocking);
     FAM_PROFILE_START_ALLOCATOR(fam_get_blocking);
     if ((local == NULL) || (descriptor == NULL) || (nbytes == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
     ret = validate_item(descriptor);
     FAM_PROFILE_END_ALLOCATOR(fam_get_blocking);
@@ -1292,7 +1306,6 @@ int fam::Impl_::fam_get_blocking(void *local, Fam_Descriptor *descriptor,
         ret = famOps->get_blocking(local, descriptor, offset, nbytes);
     }
     FAM_PROFILE_END_OPS(fam_get_blocking);
-    return ret;
 }
 
 /**
@@ -1311,7 +1324,9 @@ void fam::Impl_::fam_get_nonblocking(void *local, Fam_Descriptor *descriptor,
     FAM_CNTR_INC_API(fam_get_nonblocking);
     FAM_PROFILE_START_ALLOCATOR(fam_get_nonblocking);
     if ((local == NULL) || (descriptor == NULL) || (nbytes == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
     int ret = validate_item(descriptor);
     FAM_PROFILE_END_ALLOCATOR(fam_get_nonblocking);
@@ -1338,8 +1353,8 @@ void fam::Impl_::fam_get_nonblocking(void *local, Fam_Descriptor *descriptor,
  * @throws : Fam_Permission_Exception if the given key has incorrect permissions
  * @throws : Fam_Datapath_Exception if libfabric write fails.
  */
-int fam::Impl_::fam_put_blocking(void *local, Fam_Descriptor *descriptor,
-                                 uint64_t offset, uint64_t nbytes) {
+void fam::Impl_::fam_put_blocking(void *local, Fam_Descriptor *descriptor,
+                                  uint64_t offset, uint64_t nbytes) {
 
     int ret = 0;
     std::ostringstream message;
@@ -1347,8 +1362,9 @@ int fam::Impl_::fam_put_blocking(void *local, Fam_Descriptor *descriptor,
     FAM_CNTR_INC_API(fam_put_blocking);
     FAM_PROFILE_START_ALLOCATOR(fam_put_blocking);
     if ((local == NULL) || (descriptor == NULL) || (nbytes == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
-        return false;
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     ret = validate_item(descriptor);
@@ -1358,7 +1374,6 @@ int fam::Impl_::fam_put_blocking(void *local, Fam_Descriptor *descriptor,
         ret = famOps->put_blocking(local, descriptor, offset, nbytes);
     }
     FAM_PROFILE_END_OPS(fam_put_blocking);
-    return ret;
 }
 
 /**
@@ -1376,7 +1391,9 @@ void fam::Impl_::fam_put_nonblocking(void *local, Fam_Descriptor *descriptor,
     FAM_CNTR_INC_API(fam_put_nonblocking);
     FAM_PROFILE_START_ALLOCATOR(fam_put_nonblocking);
     if ((local == NULL) || (descriptor == NULL) || (nbytes == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1410,13 +1427,15 @@ void fam::Impl_::fam_put_nonblocking(void *local, Fam_Descriptor *descriptor,
  * negative number in case of exception
  * @see #fam_scatter_strided
  */
-int fam::Impl_::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
-                                    uint64_t nElements, uint64_t firstElement,
-                                    uint64_t stride, uint64_t elementSize) {
+void fam::Impl_::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
+                                     uint64_t nElements, uint64_t firstElement,
+                                     uint64_t stride, uint64_t elementSize) {
     FAM_CNTR_INC_API(fam_gather_blocking);
     FAM_PROFILE_START_ALLOCATOR(fam_gather_blocking);
     if ((local == NULL) || (descriptor == NULL) || (nElements == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1427,7 +1446,6 @@ int fam::Impl_::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
                                       firstElement, stride, elementSize);
     }
     FAM_PROFILE_END_OPS(fam_gather_blocking);
-    return ret;
 }
 
 /**
@@ -1446,13 +1464,15 @@ int fam::Impl_::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
  * negative number in case errors
  * @see #fam_scatter_indexed
  */
-int fam::Impl_::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
-                                    uint64_t nElements, uint64_t *elementIndex,
-                                    uint64_t elementSize) {
+void fam::Impl_::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
+                                     uint64_t nElements, uint64_t *elementIndex,
+                                     uint64_t elementSize) {
     FAM_CNTR_INC_API(fam_gather_blocking);
     FAM_PROFILE_START_ALLOCATOR(fam_gather_blocking);
     if ((local == NULL) || (descriptor == NULL) || (nElements == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1463,7 +1483,6 @@ int fam::Impl_::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
                                       elementIndex, elementSize);
     }
     FAM_PROFILE_END_OPS(fam_gather_blocking);
-    return ret;
 }
 
 /**
@@ -1488,7 +1507,9 @@ void fam::Impl_::fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
     FAM_CNTR_INC_API(fam_gather_nonblocking);
     FAM_PROFILE_START_ALLOCATOR(fam_gather_nonblocking);
     if ((local == NULL) || (descriptor == NULL) || (nElements == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1523,7 +1544,9 @@ void fam::Impl_::fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
     FAM_CNTR_INC_API(fam_gather_nonblocking);
     FAM_PROFILE_START_ALLOCATOR(fam_gather_nonblocking);
     if ((local == NULL) || (descriptor == NULL) || (nElements == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1554,14 +1577,16 @@ void fam::Impl_::fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
  * negative number in case errors
  * @see #fam_gather_strided
  */
-int fam::Impl_::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
-                                     uint64_t nElements, uint64_t firstElement,
-                                     uint64_t stride, uint64_t elementSize) {
+void fam::Impl_::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
+                                      uint64_t nElements, uint64_t firstElement,
+                                      uint64_t stride, uint64_t elementSize) {
 
     FAM_CNTR_INC_API(fam_scatter_blocking);
     FAM_PROFILE_START_ALLOCATOR(fam_scatter_blocking);
     if ((local == NULL) || (descriptor == NULL) || (nElements == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1572,7 +1597,6 @@ int fam::Impl_::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
                                        firstElement, stride, elementSize);
     }
     FAM_PROFILE_END_OPS(fam_scatter_blocking);
-    return ret;
 }
 
 /**
@@ -1590,14 +1614,17 @@ int fam::Impl_::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
  * negative number in case errors
  * @see #fam_gather_indexed
  */
-int fam::Impl_::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
-                                     uint64_t nElements, uint64_t *elementIndex,
-                                     uint64_t elementSize) {
+void fam::Impl_::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
+                                      uint64_t nElements,
+                                      uint64_t *elementIndex,
+                                      uint64_t elementSize) {
 
     FAM_CNTR_INC_API(fam_scatter_blocking);
     FAM_PROFILE_START_ALLOCATOR(fam_scatter_blocking);
     if ((local == NULL) || (descriptor == NULL) || (nElements == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1608,7 +1635,6 @@ int fam::Impl_::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
                                        elementIndex, elementSize);
     }
     FAM_PROFILE_END_OPS(fam_scatter_blocking);
-    return ret;
 }
 
 /**
@@ -1636,7 +1662,9 @@ void fam::Impl_::fam_scatter_nonblocking(void *local,
     FAM_CNTR_INC_API(fam_scatter_nonblocking);
     FAM_PROFILE_START_ALLOCATOR(fam_scatter_nonblocking);
     if ((local == NULL) || (descriptor == NULL) || (nElements == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1673,7 +1701,9 @@ void fam::Impl_::fam_scatter_nonblocking(void *local,
     FAM_CNTR_INC_API(fam_scatter_nonblocking);
     FAM_PROFILE_START_ALLOCATOR(fam_scatter_nonblocking);
     if ((local == NULL) || (descriptor == NULL) || (nElements == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1710,7 +1740,9 @@ void *fam::Impl_::fam_copy(Fam_Descriptor *src, uint64_t srcOffset,
     FAM_CNTR_INC_API(fam_copy);
     FAM_PROFILE_START_ALLOCATOR(fam_copy);
     if ((src == NULL) || (nbytes == 0)) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int retS = validate_item(src);
@@ -1728,7 +1760,9 @@ void fam::Impl_::fam_copy_wait(void *waitObj) {
     FAM_CNTR_INC_API(fam_copy_wait);
     FAM_PROFILE_START_ALLOCATOR(fam_copy_wait);
     if (waitObj == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        std::ostringstream message;
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     famOps->wait_for_copy(waitObj);
@@ -1753,7 +1787,8 @@ void fam::Impl_::fam_set(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_set);
     FAM_PROFILE_START_ALLOCATOR(fam_set);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1771,7 +1806,8 @@ void fam::Impl_::fam_set(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_set);
     FAM_PROFILE_START_ALLOCATOR(fam_set);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1790,7 +1826,8 @@ void fam::Impl_::fam_set(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_set);
     FAM_PROFILE_START_ALLOCATOR(fam_set);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1810,7 +1847,8 @@ void fam::Impl_::fam_set(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_set);
     FAM_PROFILE_START_ALLOCATOR(fam_set);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1829,7 +1867,8 @@ void fam::Impl_::fam_set(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_set);
     FAM_PROFILE_START_ALLOCATOR(fam_set);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1848,7 +1887,8 @@ void fam::Impl_::fam_set(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_set);
     FAM_PROFILE_START_ALLOCATOR(fam_set);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1867,7 +1907,8 @@ void fam::Impl_::fam_set(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_set);
     FAM_PROFILE_START_ALLOCATOR(fam_set);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1894,7 +1935,8 @@ void fam::Impl_::fam_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_add);
     FAM_PROFILE_START_ALLOCATOR(fam_add);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1913,7 +1955,8 @@ void fam::Impl_::fam_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_add);
     FAM_PROFILE_START_ALLOCATOR(fam_add);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1932,7 +1975,8 @@ void fam::Impl_::fam_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_add);
     FAM_PROFILE_START_ALLOCATOR(fam_add);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1951,7 +1995,8 @@ void fam::Impl_::fam_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_add);
     FAM_PROFILE_START_ALLOCATOR(fam_add);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1970,7 +2015,8 @@ void fam::Impl_::fam_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_add);
     FAM_PROFILE_START_ALLOCATOR(fam_add);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -1989,7 +2035,8 @@ void fam::Impl_::fam_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_add);
     FAM_PROFILE_START_ALLOCATOR(fam_add);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2017,7 +2064,8 @@ void fam::Impl_::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_subtract);
     FAM_PROFILE_START_ALLOCATOR(fam_subtract);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2036,7 +2084,8 @@ void fam::Impl_::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_subtract);
     FAM_PROFILE_START_ALLOCATOR(fam_subtract);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2055,7 +2104,8 @@ void fam::Impl_::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_subtract);
     FAM_PROFILE_START_ALLOCATOR(fam_subtract);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2074,7 +2124,8 @@ void fam::Impl_::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_subtract);
     FAM_PROFILE_START_ALLOCATOR(fam_subtract);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2093,7 +2144,8 @@ void fam::Impl_::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_subtract);
     FAM_PROFILE_START_ALLOCATOR(fam_subtract);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2112,7 +2164,8 @@ void fam::Impl_::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_subtract);
     FAM_PROFILE_START_ALLOCATOR(fam_subtract);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2140,7 +2193,8 @@ void fam::Impl_::fam_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_min);
     FAM_PROFILE_START_ALLOCATOR(fam_min);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2159,7 +2213,8 @@ void fam::Impl_::fam_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_min);
     FAM_PROFILE_START_ALLOCATOR(fam_min);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2178,7 +2233,8 @@ void fam::Impl_::fam_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_min);
     FAM_PROFILE_START_ALLOCATOR(fam_min);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2197,7 +2253,8 @@ void fam::Impl_::fam_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_min);
     FAM_PROFILE_START_ALLOCATOR(fam_min);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2216,7 +2273,8 @@ void fam::Impl_::fam_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_min);
     FAM_PROFILE_START_ALLOCATOR(fam_min);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2235,7 +2293,8 @@ void fam::Impl_::fam_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_min);
     FAM_PROFILE_START_ALLOCATOR(fam_min);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2263,7 +2322,8 @@ void fam::Impl_::fam_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_max);
     FAM_PROFILE_START_ALLOCATOR(fam_max);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2282,7 +2342,8 @@ void fam::Impl_::fam_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_max);
     FAM_PROFILE_START_ALLOCATOR(fam_max);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2301,7 +2362,8 @@ void fam::Impl_::fam_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_max);
     FAM_PROFILE_START_ALLOCATOR(fam_max);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2320,7 +2382,8 @@ void fam::Impl_::fam_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_max);
     FAM_PROFILE_START_ALLOCATOR(fam_max);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2339,7 +2402,8 @@ void fam::Impl_::fam_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_max);
     FAM_PROFILE_START_ALLOCATOR(fam_max);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2358,7 +2422,8 @@ void fam::Impl_::fam_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_max);
     FAM_PROFILE_START_ALLOCATOR(fam_max);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2386,7 +2451,8 @@ void fam::Impl_::fam_and(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_and);
     FAM_PROFILE_START_ALLOCATOR(fam_and);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2405,7 +2471,8 @@ void fam::Impl_::fam_and(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_and);
     FAM_PROFILE_START_ALLOCATOR(fam_and);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2433,7 +2500,8 @@ void fam::Impl_::fam_or(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_or);
     FAM_PROFILE_START_ALLOCATOR(fam_or);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2452,7 +2520,8 @@ void fam::Impl_::fam_or(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_or);
     FAM_PROFILE_START_ALLOCATOR(fam_or);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2480,7 +2549,8 @@ void fam::Impl_::fam_xor(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_xor);
     FAM_PROFILE_START_ALLOCATOR(fam_xor);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2499,7 +2569,8 @@ void fam::Impl_::fam_xor(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_CNTR_INC_API(fam_xor);
     FAM_PROFILE_START_ALLOCATOR(fam_xor);
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2529,7 +2600,8 @@ int32_t fam::Impl_::fam_fetch_int32(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch);
     int32_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2549,7 +2621,8 @@ int64_t fam::Impl_::fam_fetch_int64(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch);
     int64_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2569,7 +2642,8 @@ int128_t fam::Impl_::fam_fetch_int128(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch);
     int128_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2590,7 +2664,8 @@ uint32_t fam::Impl_::fam_fetch_uint32(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch);
     uint32_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2610,7 +2685,8 @@ uint64_t fam::Impl_::fam_fetch_uint64(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch);
     uint64_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2629,7 +2705,8 @@ float fam::Impl_::fam_fetch_float(Fam_Descriptor *descriptor, uint64_t offset) {
     FAM_PROFILE_START_ALLOCATOR(fam_fetch);
     float res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2649,7 +2726,8 @@ double fam::Impl_::fam_fetch_double(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch);
     double res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2679,7 +2757,8 @@ int32_t fam::Impl_::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_swap);
     int32_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2699,7 +2778,8 @@ int64_t fam::Impl_::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_swap);
     int64_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2719,7 +2799,8 @@ uint32_t fam::Impl_::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_swap);
     uint32_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2739,7 +2820,8 @@ uint64_t fam::Impl_::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_swap);
     uint64_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2759,7 +2841,8 @@ float fam::Impl_::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_swap);
     float res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2779,7 +2862,8 @@ double fam::Impl_::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_swap);
     double res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2812,7 +2896,8 @@ int32_t fam::Impl_::fam_compare_swap(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_compare_swap);
     int32_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2833,7 +2918,8 @@ int64_t fam::Impl_::fam_compare_swap(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_compare_swap);
     int64_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2854,7 +2940,8 @@ uint32_t fam::Impl_::fam_compare_swap(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_compare_swap);
     uint32_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2875,7 +2962,8 @@ uint64_t fam::Impl_::fam_compare_swap(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_compare_swap);
     uint64_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2896,7 +2984,8 @@ int128_t fam::Impl_::fam_compare_swap(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_compare_swap);
     int128_t res = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2925,7 +3014,8 @@ int32_t fam::Impl_::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_add);
     int32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2945,7 +3035,8 @@ int64_t fam::Impl_::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_add);
     int64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2965,7 +3056,8 @@ uint32_t fam::Impl_::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_add);
     uint32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -2986,7 +3078,8 @@ uint64_t fam::Impl_::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_add);
     uint64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3007,7 +3100,8 @@ float fam::Impl_::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_add);
     float old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3027,7 +3121,8 @@ double fam::Impl_::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_add);
     double old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3057,7 +3152,8 @@ int32_t fam::Impl_::fam_fetch_subtract(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_subtract);
     int32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3077,7 +3173,8 @@ int64_t fam::Impl_::fam_fetch_subtract(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_subtract);
     int64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3098,7 +3195,8 @@ uint32_t fam::Impl_::fam_fetch_subtract(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_subtract);
     uint32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3119,7 +3217,8 @@ uint64_t fam::Impl_::fam_fetch_subtract(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_subtract);
     uint64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3139,7 +3238,8 @@ float fam::Impl_::fam_fetch_subtract(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_subtract);
     float old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3159,7 +3259,8 @@ double fam::Impl_::fam_fetch_subtract(Fam_Descriptor *descriptor,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_subtract);
     double old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3190,7 +3291,8 @@ int32_t fam::Impl_::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_min);
     int32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3210,7 +3312,8 @@ int64_t fam::Impl_::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_min);
     int64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3230,7 +3333,8 @@ uint32_t fam::Impl_::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_min);
     uint32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3250,7 +3354,8 @@ uint64_t fam::Impl_::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_min);
     uint64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3270,7 +3375,8 @@ float fam::Impl_::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_min);
     float old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3290,7 +3396,8 @@ double fam::Impl_::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_min);
     double old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3321,7 +3428,8 @@ int32_t fam::Impl_::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_max);
     int32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3341,7 +3449,8 @@ int64_t fam::Impl_::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_max);
     int64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3361,7 +3470,8 @@ uint32_t fam::Impl_::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_max);
     uint32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3381,7 +3491,8 @@ uint64_t fam::Impl_::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_max);
     uint64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3401,7 +3512,8 @@ float fam::Impl_::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_max);
     float old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3421,7 +3533,8 @@ double fam::Impl_::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_max);
     double old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3452,7 +3565,8 @@ uint32_t fam::Impl_::fam_fetch_and(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_and);
     uint32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3472,7 +3586,8 @@ uint64_t fam::Impl_::fam_fetch_and(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_and);
     uint64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3503,7 +3618,8 @@ uint32_t fam::Impl_::fam_fetch_or(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_or);
     uint32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3523,7 +3639,8 @@ uint64_t fam::Impl_::fam_fetch_or(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_or);
     uint64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3554,7 +3671,8 @@ uint32_t fam::Impl_::fam_fetch_xor(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_xor);
     uint32_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3574,7 +3692,8 @@ uint64_t fam::Impl_::fam_fetch_xor(Fam_Descriptor *descriptor, uint64_t offset,
     FAM_PROFILE_START_ALLOCATOR(fam_fetch_xor);
     uint64_t old = 0;
     if (descriptor == NULL) {
-        throw Fam_InvalidOption_Exception("Invalid Options");
+        ERROR_MSG(message, "Invalid Options");
+        throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 
     int ret = validate_item(descriptor);
@@ -3631,8 +3750,10 @@ void fam::Impl_::fam_quiet(Fam_Region_Descriptor *descriptor) {
  * @see #fam_finalize()
  * @see #Fam_Options
  */
-int fam::fam_initialize(const char *groupName, Fam_Options *options) {
-    return pimpl_->fam_initialize(groupName, options);
+void fam::fam_initialize(const char *groupName, Fam_Options *options) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_initialize(groupName, options);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3642,20 +3763,30 @@ int fam::fam_initialize(const char *groupName, Fam_Options *options) {
  * @see #fam_initialize()
  */
 void fam::fam_finalize(const char *groupName) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_finalize(groupName);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
  * Forcibly terminate all PEs in the same group as the caller
  * @param status - termination status to be returned by the program.
  */
-void fam::fam_abort(int status) { pimpl_->fam_abort(status); }
+void fam::fam_abort(int status) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_abort(status);
+    RETURN_WITH_FAM_EXCEPTION
+}
 
 /**
  * Suspends the execution of the calling PE until all other PEs issue
  * a call to this particular fam_barrier_all() statement
  */
-void fam::fam_barrier_all(void) { pimpl_->fam_barrier_all(); }
+void fam::fam_barrier_all(void) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_barrier_all();
+    RETURN_WITH_FAM_EXCEPTION
+}
 
 /**
  * List known options for this version of the library. Provides a way for
@@ -3664,7 +3795,11 @@ void fam::fam_barrier_all(void) { pimpl_->fam_barrier_all(); }
  * the library
  * @see #fam_get_option()
  */
-const char **fam::fam_list_options(void) { return pimpl_->fam_list_options(); }
+const char **fam::fam_list_options(void) {
+    TRY_CATCH_BEGIN
+    return pimpl_->fam_list_options();
+    RETURN_WITH_FAM_EXCEPTION
+}
 
 /**
  * Query the FAM library for an option.
@@ -3674,7 +3809,9 @@ const char **fam::fam_list_options(void) { return pimpl_->fam_list_options(); }
  * @see #fam_list_options()
  */
 const void *fam::fam_get_option(char *optionName) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_get_option(optionName);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3687,7 +3824,9 @@ const void *fam::fam_get_option(char *optionName) {
  * @see #fam_lookup
  */
 Fam_Region_Descriptor *fam::fam_lookup_region(const char *name) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_lookup_region(name);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3701,7 +3840,9 @@ Fam_Region_Descriptor *fam::fam_lookup_region(const char *name) {
  * @see #fam_lookup_region
  */
 Fam_Descriptor *fam::fam_lookup(const char *itemName, const char *regionName) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_lookup(itemName, regionName);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 // ALLOCATION Group
@@ -3728,7 +3869,9 @@ Fam_Descriptor *fam::fam_lookup(const char *itemName, const char *regionName) {
 Fam_Region_Descriptor *
 fam::fam_create_region(const char *name, uint64_t size, mode_t permissions,
                        Fam_Redundancy_Level redundancyLevel, ...) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_create_region(name, size, permissions, redundancyLevel);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3742,7 +3885,9 @@ fam::fam_create_region(const char *name, uint64_t size, mode_t permissions,
  * @see #fam_resize_region
  */
 void fam::fam_destroy_region(Fam_Region_Descriptor *descriptor) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_destroy_region(descriptor);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3756,8 +3901,11 @@ void fam::fam_destroy_region(Fam_Region_Descriptor *descriptor) {
  * @see #fam_create_region
  * @see #fam_destroy_region
  */
-int fam::fam_resize_region(Fam_Region_Descriptor *descriptor, uint64_t nbytes) {
-    return pimpl_->fam_resize_region(descriptor, nbytes);
+void fam::fam_resize_region(Fam_Region_Descriptor *descriptor,
+                            uint64_t nbytes) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_resize_region(descriptor, nbytes);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3776,12 +3924,16 @@ int fam::fam_resize_region(Fam_Region_Descriptor *descriptor, uint64_t nbytes) {
  */
 Fam_Descriptor *fam::fam_allocate(uint64_t nbytes, mode_t accessPermissions,
                                   Fam_Region_Descriptor *region) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_allocate(nbytes, accessPermissions, region);
+    RETURN_WITH_FAM_EXCEPTION
 }
 Fam_Descriptor *fam::fam_allocate(const char *name, uint64_t nbytes,
                                   mode_t accessPermissions,
                                   Fam_Region_Descriptor *region) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_allocate(name, nbytes, accessPermissions, region);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3792,7 +3944,9 @@ Fam_Descriptor *fam::fam_allocate(const char *name, uint64_t nbytes,
  * @see #fam_allocate()
  */
 void fam::fam_deallocate(Fam_Descriptor *descriptor) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_deallocate(descriptor);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3804,9 +3958,11 @@ void fam::fam_deallocate(Fam_Descriptor *descriptor) {
  * @return - 0 on success, 1 for unsuccessful completion, negative number on an
  * exception
  */
-int fam::fam_change_permissions(Fam_Descriptor *descriptor,
-                                mode_t accessPermissions) {
-    return pimpl_->fam_change_permissions(descriptor, accessPermissions);
+void fam::fam_change_permissions(Fam_Descriptor *descriptor,
+                                 mode_t accessPermissions) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_change_permissions(descriptor, accessPermissions);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3818,9 +3974,11 @@ int fam::fam_change_permissions(Fam_Descriptor *descriptor,
  * @return - 0 on success, 1 for unsuccessful completion, negative number on an
  * exception
  */
-int fam::fam_change_permissions(Fam_Region_Descriptor *descriptor,
-                                mode_t accessPermissions) {
-    return pimpl_->fam_change_permissions(descriptor, accessPermissions);
+void fam::fam_change_permissions(Fam_Region_Descriptor *descriptor,
+                                 mode_t accessPermissions) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_change_permissions(descriptor, accessPermissions);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3833,7 +3991,9 @@ int fam::fam_change_permissions(Fam_Region_Descriptor *descriptor,
  */
 
 void fam::fam_stat(Fam_Descriptor *descriptor, Fam_Stat *famInfo) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_stat(descriptor, famInfo);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3845,7 +4005,9 @@ void fam::fam_stat(Fam_Descriptor *descriptor, Fam_Stat *famInfo) {
  * @return - none
  */
 void fam::fam_stat(Fam_Region_Descriptor *descriptor, Fam_Stat *famInfo) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_stat(descriptor, famInfo);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 // DATA READ AND WRITE Group. These APIs read and write data in FAM and copy
@@ -3870,9 +4032,11 @@ void fam::fam_stat(Fam_Region_Descriptor *descriptor, Fam_Stat *famInfo) {
  * @return - 0 for successful completion, 1 for unsuccessful, and a negative
  * number in case of exceptions
  */
-int fam::fam_get_blocking(void *local, Fam_Descriptor *descriptor,
-                          uint64_t offset, uint64_t nbytes) {
-    return pimpl_->fam_get_blocking(local, descriptor, offset, nbytes);
+void fam::fam_get_blocking(void *local, Fam_Descriptor *descriptor,
+                           uint64_t offset, uint64_t nbytes) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_get_blocking(local, descriptor, offset, nbytes);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3891,7 +4055,9 @@ int fam::fam_get_blocking(void *local, Fam_Descriptor *descriptor,
  */
 void fam::fam_get_nonblocking(void *local, Fam_Descriptor *descriptor,
                               uint64_t offset, uint64_t nbytes) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_get_nonblocking(local, descriptor, offset, nbytes);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3910,9 +4076,11 @@ void fam::fam_get_nonblocking(void *local, Fam_Descriptor *descriptor,
  * @return - 0 for successful completion, 1 for unsuccessful completion,
  * negative number in case of exceptions
  */
-int fam::fam_put_blocking(void *local, Fam_Descriptor *descriptor,
-                          uint64_t offset, uint64_t nbytes) {
-    return pimpl_->fam_put_blocking(local, descriptor, offset, nbytes);
+void fam::fam_put_blocking(void *local, Fam_Descriptor *descriptor,
+                           uint64_t offset, uint64_t nbytes) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_put_blocking(local, descriptor, offset, nbytes);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3931,7 +4099,9 @@ int fam::fam_put_blocking(void *local, Fam_Descriptor *descriptor,
  */
 void fam::fam_put_nonblocking(void *local, Fam_Descriptor *descriptor,
                               uint64_t offset, uint64_t nbytes) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_put_nonblocking(local, descriptor, offset, nbytes);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 // LOAD/STORE sub-group
@@ -3945,7 +4115,9 @@ void fam::fam_put_nonblocking(void *local, Fam_Descriptor *descriptor,
  * @see #fam_unmap()
  */
 void *fam::fam_map(Fam_Descriptor *descriptor) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_map(descriptor);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -3956,7 +4128,9 @@ void *fam::fam_map(Fam_Descriptor *descriptor) {
  * @see #fam_map()
  */
 void fam::fam_unmap(void *local, Fam_Descriptor *descriptor) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_unmap(local, descriptor);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 // GATHER/SCATTER subgroup
@@ -3983,11 +4157,13 @@ void fam::fam_unmap(void *local, Fam_Descriptor *descriptor) {
  * negative number in case of exception
  * @see #fam_scatter_strided
  */
-int fam::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
-                             uint64_t nElements, uint64_t firstElement,
-                             uint64_t stride, uint64_t elementSize) {
-    return pimpl_->fam_gather_blocking(local, descriptor, nElements,
-                                       firstElement, stride, elementSize);
+void fam::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
+                              uint64_t nElements, uint64_t firstElement,
+                              uint64_t stride, uint64_t elementSize) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_gather_blocking(local, descriptor, nElements, firstElement,
+                                stride, elementSize);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4011,11 +4187,13 @@ int fam::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
  * negative number in case errors
  * @see #fam_scatter_indexed
  */
-int fam::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
-                             uint64_t nElements, uint64_t *elementIndex,
-                             uint64_t elementSize) {
-    return pimpl_->fam_gather_blocking(local, descriptor, nElements,
-                                       elementIndex, elementSize);
+void fam::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
+                              uint64_t nElements, uint64_t *elementIndex,
+                              uint64_t elementSize) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_gather_blocking(local, descriptor, nElements, elementIndex,
+                                elementSize);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4040,8 +4218,10 @@ int fam::fam_gather_blocking(void *local, Fam_Descriptor *descriptor,
 void fam::fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
                                  uint64_t nElements, uint64_t firstElement,
                                  uint64_t stride, uint64_t elementSize) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_gather_nonblocking(local, descriptor, nElements, firstElement,
                                    stride, elementSize);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4065,8 +4245,10 @@ void fam::fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
 void fam::fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
                                  uint64_t nElements, uint64_t *elementIndex,
                                  uint64_t elementSize) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_gather_nonblocking(local, descriptor, nElements, elementIndex,
                                    elementSize);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4091,11 +4273,13 @@ void fam::fam_gather_nonblocking(void *local, Fam_Descriptor *descriptor,
  * negative number in case errors
  * @see #fam_gather_strided
  */
-int fam::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
-                              uint64_t nElements, uint64_t firstElement,
-                              uint64_t stride, uint64_t elementSize) {
-    return pimpl_->fam_scatter_blocking(local, descriptor, nElements,
-                                        firstElement, stride, elementSize);
+void fam::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
+                               uint64_t nElements, uint64_t firstElement,
+                               uint64_t stride, uint64_t elementSize) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_scatter_blocking(local, descriptor, nElements, firstElement,
+                                 stride, elementSize);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4118,11 +4302,13 @@ int fam::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
  * negative number in case errors
  * @see #fam_gather_indexed
  */
-int fam::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
-                              uint64_t nElements, uint64_t *elementIndex,
-                              uint64_t elementSize) {
-    return pimpl_->fam_scatter_blocking(local, descriptor, nElements,
-                                        elementIndex, elementSize);
+void fam::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
+                               uint64_t nElements, uint64_t *elementIndex,
+                               uint64_t elementSize) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_scatter_blocking(local, descriptor, nElements, elementIndex,
+                                 elementSize);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4149,8 +4335,10 @@ int fam::fam_scatter_blocking(void *local, Fam_Descriptor *descriptor,
 void fam::fam_scatter_nonblocking(void *local, Fam_Descriptor *descriptor,
                                   uint64_t nElements, uint64_t firstElement,
                                   uint64_t stride, uint64_t elementSize) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_scatter_nonblocking(local, descriptor, nElements, firstElement,
                                     stride, elementSize);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4175,8 +4363,10 @@ void fam::fam_scatter_nonblocking(void *local, Fam_Descriptor *descriptor,
 void fam::fam_scatter_nonblocking(void *local, Fam_Descriptor *descriptor,
                                   uint64_t nElements, uint64_t *elementIndex,
                                   uint64_t elementSize) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_scatter_nonblocking(local, descriptor, nElements, elementIndex,
                                     elementSize);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 // COPY Subgroup
@@ -4201,10 +4391,17 @@ void fam::fam_scatter_nonblocking(void *local, Fam_Descriptor *descriptor,
 void *fam::fam_copy(Fam_Descriptor *src, uint64_t srcOffset,
                     Fam_Descriptor *dest, uint64_t destOffset,
                     uint64_t nbytes) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_copy(src, srcOffset, dest, destOffset, nbytes);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
-void fam::fam_copy_wait(void *waitObj) { pimpl_->fam_copy_wait(waitObj); }
+void fam::fam_copy_wait(void *waitObj) {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_copy_wait(waitObj);
+    RETURN_WITH_FAM_EXCEPTION
+}
+
 
 // ATOMICS Group
 
@@ -4223,25 +4420,39 @@ void fam::fam_copy_wait(void *waitObj) { pimpl_->fam_copy_wait(waitObj); }
  *         FAM_ERR_NOPERM, FAM_ERR_NOTFOUND, FAM_ERR_RPC
  */
 void fam::fam_set(Fam_Descriptor *descriptor, uint64_t offset, int32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_set(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_set(Fam_Descriptor *descriptor, uint64_t offset, int64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_set(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_set(Fam_Descriptor *descriptor, uint64_t offset, int128_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_set(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_set(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_set(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_set(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_set(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_set(Fam_Descriptor *descriptor, uint64_t offset, float value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_set(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_set(Fam_Descriptor *descriptor, uint64_t offset, double value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_set(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4257,22 +4468,34 @@ void fam::fam_set(Fam_Descriptor *descriptor, uint64_t offset, double value) {
  *         FAM_ERR_NOPERM, FAM_ERR_NOTFOUND, FAM_ERR_RPC
  */
 void fam::fam_add(Fam_Descriptor *descriptor, uint64_t offset, int32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_add(Fam_Descriptor *descriptor, uint64_t offset, int64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_add(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_add(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_add(Fam_Descriptor *descriptor, uint64_t offset, float value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_add(Fam_Descriptor *descriptor, uint64_t offset, double value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4290,27 +4513,39 @@ void fam::fam_add(Fam_Descriptor *descriptor, uint64_t offset, double value) {
  */
 void fam::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                        int32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                        int64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                        uint32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                        uint64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                        float value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                        double value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4327,22 +4562,34 @@ void fam::fam_subtract(Fam_Descriptor *descriptor, uint64_t offset,
  *         FAM_ERR_NOPERM, FAM_ERR_NOTFOUND, FAM_ERR_RPC
  */
 void fam::fam_min(Fam_Descriptor *descriptor, uint64_t offset, int32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_min(Fam_Descriptor *descriptor, uint64_t offset, int64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_min(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_min(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_min(Fam_Descriptor *descriptor, uint64_t offset, float value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_min(Fam_Descriptor *descriptor, uint64_t offset, double value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4359,22 +4606,34 @@ void fam::fam_min(Fam_Descriptor *descriptor, uint64_t offset, double value) {
  *         FAM_ERR_NOPERM, FAM_ERR_NOTFOUND, FAM_ERR_RPC
  */
 void fam::fam_max(Fam_Descriptor *descriptor, uint64_t offset, int32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_max(Fam_Descriptor *descriptor, uint64_t offset, int64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_max(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_max(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_max(Fam_Descriptor *descriptor, uint64_t offset, float value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_max(Fam_Descriptor *descriptor, uint64_t offset, double value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4391,10 +4650,14 @@ void fam::fam_max(Fam_Descriptor *descriptor, uint64_t offset, double value) {
  *         FAM_ERR_NOPERM, FAM_ERR_NOTFOUND, FAM_ERR_RPC
  */
 void fam::fam_and(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_and(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_and(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_and(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4411,10 +4674,14 @@ void fam::fam_and(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
  *         FAM_ERR_NOPERM, FAM_ERR_NOTFOUND, FAM_ERR_RPC
  */
 void fam::fam_or(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_or(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_or(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_or(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4431,10 +4698,14 @@ void fam::fam_or(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
  *         FAM_ERR_NOPERM, FAM_ERR_NOTFOUND, FAM_ERR_RPC
  */
 void fam::fam_xor(Fam_Descriptor *descriptor, uint64_t offset, uint32_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_xor(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 void fam::fam_xor(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
+    TRY_CATCH_BEGIN
     pimpl_->fam_xor(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 // FETCHING Routines - perform the operation, and return the old value in FAM
@@ -4452,25 +4723,39 @@ void fam::fam_xor(Fam_Descriptor *descriptor, uint64_t offset, uint64_t value) {
  * @return - value from the given location in FAM
  */
 int32_t fam::fam_fetch_int32(Fam_Descriptor *descriptor, uint64_t offset) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_int32(descriptor, offset);
+    RETURN_WITH_FAM_EXCEPTION
 }
 int64_t fam::fam_fetch_int64(Fam_Descriptor *descriptor, uint64_t offset) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_int64(descriptor, offset);
+    RETURN_WITH_FAM_EXCEPTION
 }
 int128_t fam::fam_fetch_int128(Fam_Descriptor *descriptor, uint64_t offset) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_int128(descriptor, offset);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint32_t fam::fam_fetch_uint32(Fam_Descriptor *descriptor, uint64_t offset) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_uint32(descriptor, offset);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_fetch_uint64(Fam_Descriptor *descriptor, uint64_t offset) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_uint64(descriptor, offset);
+    RETURN_WITH_FAM_EXCEPTION
 }
 float fam::fam_fetch_float(Fam_Descriptor *descriptor, uint64_t offset) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_float(descriptor, offset);
+    RETURN_WITH_FAM_EXCEPTION
 }
 double fam::fam_fetch_double(Fam_Descriptor *descriptor, uint64_t offset) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_double(descriptor, offset);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4489,26 +4774,38 @@ double fam::fam_fetch_double(Fam_Descriptor *descriptor, uint64_t offset) {
  */
 int32_t fam::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
                       int32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_swap(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 int64_t fam::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
                       int64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_swap(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint32_t fam::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
                        uint32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_swap(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
                        uint64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_swap(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 float fam::fam_swap(Fam_Descriptor *descriptor, uint64_t offset, float value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_swap(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 double fam::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
                      double value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_swap(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4529,23 +4826,33 @@ double fam::fam_swap(Fam_Descriptor *descriptor, uint64_t offset,
  */
 int32_t fam::fam_compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
                               int32_t oldValue, int32_t newValue) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_compare_swap(descriptor, offset, oldValue, newValue);
+    RETURN_WITH_FAM_EXCEPTION
 }
 int64_t fam::fam_compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
                               int64_t oldValue, int64_t newValue) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_compare_swap(descriptor, offset, oldValue, newValue);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint32_t fam::fam_compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
                                uint32_t oldValue, uint32_t newValue) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_compare_swap(descriptor, offset, oldValue, newValue);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
                                uint64_t oldValue, uint64_t newValue) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_compare_swap(descriptor, offset, oldValue, newValue);
+    RETURN_WITH_FAM_EXCEPTION
 }
 int128_t fam::fam_compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
                                int128_t oldValue, int128_t newValue) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_compare_swap(descriptor, offset, oldValue, newValue);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4563,27 +4870,39 @@ int128_t fam::fam_compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
  */
 int32_t fam::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
                            int32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 int64_t fam::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
                            int64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint32_t fam::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
                             uint32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
                             uint64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 float fam::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
                          float value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 double fam::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
                           double value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_add(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4602,27 +4921,39 @@ double fam::fam_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
  */
 int32_t fam::fam_fetch_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                                 int32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 int64_t fam::fam_fetch_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                                 int64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint32_t fam::fam_fetch_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                                  uint32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_fetch_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                                  uint64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 float fam::fam_fetch_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                               float value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 double fam::fam_fetch_subtract(Fam_Descriptor *descriptor, uint64_t offset,
                                double value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_subtract(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4642,27 +4973,39 @@ double fam::fam_fetch_subtract(Fam_Descriptor *descriptor, uint64_t offset,
  */
 int32_t fam::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
                            int32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 int64_t fam::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
                            int64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint32_t fam::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
                             uint32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
                             uint64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 float fam::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
                          float value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 double fam::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
                           double value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_min(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4682,27 +5025,39 @@ double fam::fam_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
  */
 int32_t fam::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
                            int32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 int64_t fam::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
                            int64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint32_t fam::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
                             uint32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
                             uint64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 float fam::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
                          float value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 double fam::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
                           double value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_max(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4722,11 +5077,15 @@ double fam::fam_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
  */
 uint32_t fam::fam_fetch_and(Fam_Descriptor *descriptor, uint64_t offset,
                             uint32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_and(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_fetch_and(Fam_Descriptor *descriptor, uint64_t offset,
                             uint64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_and(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4746,11 +5105,15 @@ uint64_t fam::fam_fetch_and(Fam_Descriptor *descriptor, uint64_t offset,
  */
 uint32_t fam::fam_fetch_or(Fam_Descriptor *descriptor, uint64_t offset,
                            uint32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_or(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_fetch_or(Fam_Descriptor *descriptor, uint64_t offset,
                            uint64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_or(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 /**
@@ -4770,11 +5133,15 @@ uint64_t fam::fam_fetch_or(Fam_Descriptor *descriptor, uint64_t offset,
  */
 uint32_t fam::fam_fetch_xor(Fam_Descriptor *descriptor, uint64_t offset,
                             uint32_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_xor(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 uint64_t fam::fam_fetch_xor(Fam_Descriptor *descriptor, uint64_t offset,
                             uint64_t value) {
+    TRY_CATCH_BEGIN
     return pimpl_->fam_fetch_xor(descriptor, offset, value);
+    RETURN_WITH_FAM_EXCEPTION
 }
 
 // MEMORY ORDERING Routines - provide ordering of FAM operations issued by a PE
@@ -4787,7 +5154,11 @@ uint64_t fam::fam_fetch_xor(Fam_Descriptor *descriptor, uint64_t offset,
  * @throws Fam_Datapath_Exception.
  * @throws Fam_Timeout_Exception.
  */
-void fam::fam_fence() { pimpl_->fam_fence(); }
+void fam::fam_fence() {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_fence();
+    RETURN_WITH_FAM_EXCEPTION
+}
 
 /**
  * fam_quiet - blocks the calling PE thread until all its pending FAM operations
@@ -4797,7 +5168,11 @@ void fam::fam_fence() { pimpl_->fam_fence(); }
  * @throws Fam_Datapath_Exception.
  * @throws Fam_Timeout_Exception.
  */
-void fam::fam_quiet() { pimpl_->fam_quiet(); }
+void fam::fam_quiet() {
+    TRY_CATCH_BEGIN
+    pimpl_->fam_quiet();
+    RETURN_WITH_FAM_EXCEPTION
+}
 
 /**
  * fam() - constructor for fam class

--- a/src/fam-api/fam_ops_libfabric.cpp
+++ b/src/fam-api/fam_ops_libfabric.cpp
@@ -36,6 +36,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "common/fam_internal.h"
 #include "common/fam_libfabric.h"
 #include "common/fam_ops.h"
 #include "common/fam_ops_libfabric.h"
@@ -86,8 +87,9 @@ Fam_Ops_Libfabric::Fam_Ops_Libfabric(const char *memServerName,
     serverAddrName = NULL;
 
     if (!isSource && famAllocator == NULL) {
-        message << "Fam Invalid Option Fam_Alloctor: NULL value specified"
-                << famContextModel;
+        ERROR_MSG(message,
+                  "Fam Invalid Option Fam_Alloctor: NULL value specified",
+                  famContextModel);
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 }
@@ -120,8 +122,9 @@ Fam_Ops_Libfabric::Fam_Ops_Libfabric(MemServerMap memServerList,
     serverAddrName = NULL;
 
     if (!isSource && famAllocator == NULL) {
-        message << "Fam Invalid Option Fam_Alloctor: NULL value specified"
-                << famContextModel;
+        ERROR_MSG(message,
+                  "Fam Invalid Option Fam_Alloctor: NULL value specified",
+                  famContextModel);
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 }
@@ -131,7 +134,8 @@ int Fam_Ops_Libfabric::initialize() {
     int ret = 0;
 
     if (name.size() == 0) {
-        message << "Libfabric initialize: memory server name not specified";
+        ERROR_MSG(message,
+                  "Libfabric initialize: memory server name not specified");
         throw Fam_Datapath_Exception(message.str().c_str());
     }
 
@@ -165,7 +169,7 @@ int Fam_Ops_Libfabric::initialize() {
             // Request memory server address from famAllocator
             ret = famAllocator->get_addr_size(&serverAddrNameLen, nodeId);
             if (serverAddrNameLen <= 0) {
-                message << "Fam allocator get_addr_size failed";
+                ERROR_MSG(message, "Fam allocator get_addr_size failed");
                 throw Fam_Allocator_Exception(FAM_ERR_ALLOCATOR,
                                               message.str().c_str());
             }
@@ -173,7 +177,7 @@ int Fam_Ops_Libfabric::initialize() {
             ret = famAllocator->get_addr(serverAddrName, serverAddrNameLen,
                                          nodeId);
             if (ret < 0) {
-                message << "Fam Allocator get_addr failed";
+                ERROR_MSG(message, "Fam Allocator get_addr failed");
                 throw Fam_Allocator_Exception(FAM_ERR_ALLOCATOR,
                                               message.str().c_str());
             }
@@ -200,24 +204,24 @@ int Fam_Ops_Libfabric::initialize() {
             Fam_Context *tmpCtx = new Fam_Context(fi, domain, famThreadModel);
             ret = fabric_enable_bind_ep(fi, av, eq, tmpCtx->get_ep());
             if (ret < 0) {
-                message << "Fam libfabric fabric_enable_bind_ep failed: "
-                        << fabric_strerror(ret);
+                ERROR_MSG(message, "Fam libfabric fabric_enable_bind_ep failed",
+                          fabric_strerror(ret));
                 throw Fam_Datapath_Exception(message.str().c_str());
             }
 
             serverAddrNameLen = 0;
             ret = fabric_getname_len(tmpCtx->get_ep(), &serverAddrNameLen);
             if (serverAddrNameLen <= 0) {
-                message << "Fam libfabric fabric_getname_len failed: "
-                        << fabric_strerror(ret);
+                ERROR_MSG(message, "Fam libfabric fabric_getname_len failed",
+                          fabric_strerror(ret));
                 throw Fam_Datapath_Exception(message.str().c_str());
             }
             serverAddrName = calloc(1, serverAddrNameLen);
             ret = fabric_getname(tmpCtx->get_ep(), serverAddrName,
                                  &serverAddrNameLen);
             if (ret < 0) {
-                message << "Fam libfabric fabric_getname failed: "
-                        << fabric_strerror(ret);
+                ERROR_MSG(message, "Fam libfabric fabric_getname failed",
+                          fabric_strerror(ret));
                 throw Fam_Datapath_Exception(message.str().c_str());
             }
 
@@ -257,8 +261,8 @@ Fam_Context *Fam_Ops_Libfabric::get_context(Fam_Descriptor *descriptor) {
             if (ret < 0) {
                 // ctx mutex unlock
                 (void)pthread_mutex_unlock(&ctxLock);
-                message << "Fam libfabric fabric_enable_bind_ep failed: "
-                        << fabric_strerror(ret);
+                ERROR_MSG(message, "Fam libfabric fabric_enable_bind_ep failed",
+                          fabric_strerror(ret));
                 throw Fam_Datapath_Exception(message.str().c_str());
             }
         } else {
@@ -270,7 +274,8 @@ Fam_Context *Fam_Ops_Libfabric::get_context(Fam_Descriptor *descriptor) {
         (void)pthread_mutex_unlock(&ctxLock);
         return ctx;
     } else {
-        message << "Fam Invalid Option FAM_CONTEXT_MODEL: " << famContextModel;
+        ERROR_MSG(message, "Fam Invalid Option FAM_CONTEXT_MODEL",
+                  famContextModel);
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 }

--- a/src/fam-api/fam_ops_libfabric.cpp
+++ b/src/fam-api/fam_ops_libfabric.cpp
@@ -87,10 +87,9 @@ Fam_Ops_Libfabric::Fam_Ops_Libfabric(const char *memServerName,
     serverAddrName = NULL;
 
     if (!isSource && famAllocator == NULL) {
-        ERROR_MSG(message,
-                  "Fam Invalid Option Fam_Alloctor: NULL value specified",
-                  famContextModel);
-        throw Fam_InvalidOption_Exception(message.str().c_str());
+        message << "Fam Invalid Option Fam_Alloctor: NULL value specified"
+                << famContextModel;
+        THROW_ERR_MSG(Fam_InvalidOption_Exception, message.str().c_str());
     }
 }
 Fam_Ops_Libfabric::Fam_Ops_Libfabric(MemServerMap memServerList,
@@ -122,10 +121,9 @@ Fam_Ops_Libfabric::Fam_Ops_Libfabric(MemServerMap memServerList,
     serverAddrName = NULL;
 
     if (!isSource && famAllocator == NULL) {
-        ERROR_MSG(message,
-                  "Fam Invalid Option Fam_Alloctor: NULL value specified",
-                  famContextModel);
-        throw Fam_InvalidOption_Exception(message.str().c_str());
+        message << "Fam Invalid Option Fam_Alloctor: NULL value specified"
+                << famContextModel;
+        THROW_ERR_MSG(Fam_InvalidOption_Exception, message.str().c_str());
     }
 }
 
@@ -134,9 +132,8 @@ int Fam_Ops_Libfabric::initialize() {
     int ret = 0;
 
     if (name.size() == 0) {
-        ERROR_MSG(message,
-                  "Libfabric initialize: memory server name not specified");
-        throw Fam_Datapath_Exception(message.str().c_str());
+        message << "Libfabric initialize: memory server name not specified";
+        THROW_ERR_MSG(Fam_Datapath_Exception, message.str().c_str());
     }
 
     // Initialize the mutex lock
@@ -169,17 +166,17 @@ int Fam_Ops_Libfabric::initialize() {
             // Request memory server address from famAllocator
             ret = famAllocator->get_addr_size(&serverAddrNameLen, nodeId);
             if (serverAddrNameLen <= 0) {
-                ERROR_MSG(message, "Fam allocator get_addr_size failed");
-                throw Fam_Allocator_Exception(FAM_ERR_ALLOCATOR,
-                                              message.str().c_str());
+                message << "Fam allocator get_addr_size failed";
+                THROW_ERRNO_MSG(Fam_Allocator_Exception, FAM_ERR_ALLOCATOR,
+                                message.str().c_str());
             }
             serverAddrName = calloc(1, serverAddrNameLen);
             ret = famAllocator->get_addr(serverAddrName, serverAddrNameLen,
                                          nodeId);
             if (ret < 0) {
-                ERROR_MSG(message, "Fam Allocator get_addr failed");
-                throw Fam_Allocator_Exception(FAM_ERR_ALLOCATOR,
-                                              message.str().c_str());
+                message << "Fam Allocator get_addr failed";
+                THROW_ERRNO_MSG(Fam_Allocator_Exception, FAM_ERR_ALLOCATOR,
+                                message.str().c_str());
             }
 
             // Initialize defaultCtx
@@ -204,25 +201,25 @@ int Fam_Ops_Libfabric::initialize() {
             Fam_Context *tmpCtx = new Fam_Context(fi, domain, famThreadModel);
             ret = fabric_enable_bind_ep(fi, av, eq, tmpCtx->get_ep());
             if (ret < 0) {
-                ERROR_MSG(message, "Fam libfabric fabric_enable_bind_ep failed",
-                          fabric_strerror(ret));
-                throw Fam_Datapath_Exception(message.str().c_str());
+                message << "Fam libfabric fabric_enable_bind_ep failed: "
+                        << fabric_strerror(ret);
+                THROW_ERR_MSG(Fam_Datapath_Exception, message.str().c_str());
             }
 
             serverAddrNameLen = 0;
             ret = fabric_getname_len(tmpCtx->get_ep(), &serverAddrNameLen);
             if (serverAddrNameLen <= 0) {
-                ERROR_MSG(message, "Fam libfabric fabric_getname_len failed",
-                          fabric_strerror(ret));
-                throw Fam_Datapath_Exception(message.str().c_str());
+                message << "Fam libfabric fabric_getname_len failed: "
+                        << fabric_strerror(ret);
+                THROW_ERR_MSG(Fam_Datapath_Exception, message.str().c_str());
             }
             serverAddrName = calloc(1, serverAddrNameLen);
             ret = fabric_getname(tmpCtx->get_ep(), serverAddrName,
                                  &serverAddrNameLen);
             if (ret < 0) {
-                ERROR_MSG(message, "Fam libfabric fabric_getname failed",
-                          fabric_strerror(ret));
-                throw Fam_Datapath_Exception(message.str().c_str());
+                message << "Fam libfabric fabric_getname failed: "
+                        << fabric_strerror(ret);
+                THROW_ERR_MSG(Fam_Datapath_Exception, message.str().c_str());
             }
 
             // Save this context to defContexts on memoryserver
@@ -261,9 +258,9 @@ Fam_Context *Fam_Ops_Libfabric::get_context(Fam_Descriptor *descriptor) {
             if (ret < 0) {
                 // ctx mutex unlock
                 (void)pthread_mutex_unlock(&ctxLock);
-                ERROR_MSG(message, "Fam libfabric fabric_enable_bind_ep failed",
-                          fabric_strerror(ret));
-                throw Fam_Datapath_Exception(message.str().c_str());
+                message << "Fam libfabric fabric_enable_bind_ep failed: "
+                        << fabric_strerror(ret);
+                THROW_ERR_MSG(Fam_Datapath_Exception, message.str().c_str());
             }
         } else {
             ctx = ctxObj->second;
@@ -274,9 +271,8 @@ Fam_Context *Fam_Ops_Libfabric::get_context(Fam_Descriptor *descriptor) {
         (void)pthread_mutex_unlock(&ctxLock);
         return ctx;
     } else {
-        ERROR_MSG(message, "Fam Invalid Option FAM_CONTEXT_MODEL",
-                  famContextModel);
-        throw Fam_InvalidOption_Exception(message.str().c_str());
+        message << "Fam Invalid Option FAM_CONTEXT_MODEL: " << famContextModel;
+        THROW_ERR_MSG(Fam_InvalidOption_Exception, message.str().c_str());
     }
 }
 

--- a/src/fam-api/fam_ops_shm.cpp
+++ b/src/fam-api/fam_ops_shm.cpp
@@ -113,9 +113,8 @@ Fam_Context *Fam_Ops_SHM::get_context(Fam_Descriptor *descriptor) {
         (void)pthread_mutex_unlock(&ctxLock);
         return ctx;
     } else {
-        ERROR_MSG(message, "Fam Invalid Option FAM_CONTEXT_MODEL",
-                  famContextModel);
-        throw Fam_InvalidOption_Exception(message.str().c_str());
+        message << "Fam Invalid Option FAM_CONTEXT_MODEL: " << famContextModel;
+        THROW_ERR_MSG(Fam_InvalidOption_Exception, message.str().c_str());
     }
 }
 
@@ -126,15 +125,13 @@ int Fam_Ops_SHM::put_blocking(void *local, Fam_Descriptor *descriptor,
     uint64_t key = descriptor->get_key();
 
     if ((offset > size) || ((offset + nbytes) > size)) {
-        std::ostringstream message;
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        std::ostringstream message;
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     void *dest = (void *)((uint64_t)base + offset);
@@ -158,16 +155,15 @@ int Fam_Ops_SHM::get_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + nbytes) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to read from dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to read from dataitem");
     }
 
     void *src = (void *)((uint64_t)base + offset);
@@ -192,7 +188,6 @@ int Fam_Ops_SHM::gather_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     void *src;
     void *dest;
@@ -200,13 +195,13 @@ int Fam_Ops_SHM::gather_blocking(void *local, Fam_Descriptor *descriptor,
     if (((firstElement * elementSize) > size) ||
         ((firstElement * elementSize) + elementSize * stride * nElements) >
             size) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to read from dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to read from dataitem");
     }
 
     Fam_Context *famCtx = get_context(descriptor);
@@ -234,7 +229,6 @@ int Fam_Ops_SHM::gather_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     void *src;
     void *dest;
@@ -246,13 +240,13 @@ int Fam_Ops_SHM::gather_blocking(void *local, Fam_Descriptor *descriptor,
     }
 
     if ((maxOffset > size) || ((maxOffset + elementSize) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to read from dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to read from dataitem");
     }
 
     Fam_Context *famCtx = get_context(descriptor);
@@ -279,7 +273,6 @@ int Fam_Ops_SHM::scatter_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     void *src;
     void *dest;
@@ -287,13 +280,13 @@ int Fam_Ops_SHM::scatter_blocking(void *local, Fam_Descriptor *descriptor,
     if (((firstElement * elementSize) > size) ||
         ((firstElement * elementSize) + elementSize * stride * nElements) >
             size) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     Fam_Context *famCtx = get_context(descriptor);
@@ -321,7 +314,6 @@ int Fam_Ops_SHM::scatter_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     void *src;
     void *dest;
@@ -333,13 +325,13 @@ int Fam_Ops_SHM::scatter_blocking(void *local, Fam_Descriptor *descriptor,
     }
 
     if ((maxOffset > size) || ((maxOffset + elementSize) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     Fam_Context *famCtx = get_context(descriptor);
@@ -600,20 +592,17 @@ void *Fam_Ops_SHM::copy(Fam_Descriptor *src, uint64_t srcOffset,
     Fam_Region_Item_Info srcInfo = famAllocator->check_permission_get_info(src);
     Fam_Region_Item_Info destInfo =
         famAllocator->check_permission_get_info(dest);
-    std::ostringstream message;
 
     if ((srcOffset > srcInfo.size) || ((srcOffset + nbytes) > srcInfo.size)) {
-        ERROR_MSG(message, "Source offset or size is beyond dataitem boundary");
-        throw Fam_Allocator_Exception(FAM_ERR_OUTOFRANGE,
-                                      message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Allocator_Exception, FAM_ERR_OUTOFRANGE,
+                        "Source offset or size is beyond dataitem boundary");
     }
 
     if ((destOffset > destInfo.size) ||
         ((destOffset + nbytes) > destInfo.size)) {
-        ERROR_MSG(message,
-                  "Destination offset or size is beyond dataitem boundary");
-        throw Fam_Allocator_Exception(FAM_ERR_OUTOFRANGE,
-                                      message.str().c_str());
+        THROW_ERRNO_MSG(
+            Fam_Allocator_Exception, FAM_ERR_OUTOFRANGE,
+            "Destination offset or size is beyond dataitem boundary");
     }
 
     Copy_Tag *tag = new Copy_Tag();
@@ -649,16 +638,15 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     fam_atomic_32_write((int32_t *)((char *)base + offset), value);
@@ -669,16 +657,15 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     fam_atomic_64_write((int64_t *)((char *)base + offset), value);
@@ -689,16 +676,15 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int128_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     int128store oldValueStore;
@@ -711,16 +697,15 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     fam_atomic_32_write((int32_t *)((char *)base + offset), value);
@@ -731,16 +716,15 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     fam_atomic_64_write((int64_t *)((char *)base + offset), value);
@@ -751,16 +735,15 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     int32_t *buff = reinterpret_cast<int32_t *>(&value);
     fam_atomic_32_write((int32_t *)((char *)base + offset), *buff);
@@ -771,16 +754,15 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     int64_t *buff = reinterpret_cast<int64_t *>(&value);
     fam_atomic_64_write((int64_t *)((char *)base + offset), *buff);
@@ -792,16 +774,15 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     fam_atomic_32_fetch_add((int32_t *)((char *)base + offset), value);
 }
@@ -812,16 +793,15 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     fam_atomic_64_fetch_add((int64_t *)((char *)base + offset), value);
 }
@@ -832,16 +812,15 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     fam_atomic_32_fetch_add((int32_t *)((char *)base + offset), value);
 }
@@ -852,16 +831,15 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     fam_atomic_64_fetch_add((int64_t *)((char *)base + offset), value);
 }
@@ -872,16 +850,15 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_SUM][FLOAT](
@@ -894,16 +871,15 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_SUM][DOUBLE](
@@ -940,16 +916,15 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     void *result;
@@ -962,16 +937,15 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][INT64](
@@ -983,16 +957,15 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     void *result;
@@ -1005,16 +978,15 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][UINT64](
@@ -1026,16 +998,15 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][FLOAT](
@@ -1047,16 +1018,15 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     void *result;
@@ -1069,16 +1039,15 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     void *result;
@@ -1091,18 +1060,16 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
-
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][INT64](
         (void *)((char *)base + offset), (void *)&value, result);
@@ -1113,16 +1080,15 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     void *result;
@@ -1135,16 +1101,15 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][UINT64](
@@ -1156,16 +1121,15 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][FLOAT](
@@ -1177,16 +1141,15 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     void *result;
@@ -1199,16 +1162,15 @@ void Fam_Ops_SHM::atomic_and(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     void *result;
@@ -1221,16 +1183,15 @@ void Fam_Ops_SHM::atomic_and(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BAND][UINT64](
@@ -1242,16 +1203,15 @@ void Fam_Ops_SHM::atomic_or(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BOR][UINT32](
@@ -1263,16 +1223,15 @@ void Fam_Ops_SHM::atomic_or(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BOR][UINT64](
@@ -1284,16 +1243,15 @@ void Fam_Ops_SHM::atomic_xor(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BXOR][UINT32](
@@ -1305,16 +1263,15 @@ void Fam_Ops_SHM::atomic_xor(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BXOR][UINT64](
@@ -1327,16 +1284,15 @@ int32_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     return fam_atomic_32_compare_store((int32_t *)((char *)base + offset),
@@ -1349,17 +1305,16 @@ int64_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     return fam_atomic_64_compare_store((int64_t *)((char *)base + offset),
@@ -1372,17 +1327,16 @@ int128_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int128_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     int128store oldValueStore;
     int128store newValueStore;
@@ -1400,17 +1354,16 @@ uint32_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     return fam_atomic_32_compare_store((int32_t *)((char *)base + offset),
@@ -1422,17 +1375,16 @@ uint64_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     return fam_atomic_64_compare_store((int64_t *)((char *)base + offset),
@@ -1444,17 +1396,16 @@ int32_t Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     return fam_atomic_32_swap((int32_t *)((char *)base + offset), value);
 }
@@ -1464,17 +1415,16 @@ int64_t Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     return fam_atomic_64_swap((int64_t *)((char *)base + offset), value);
 }
@@ -1484,17 +1434,16 @@ uint32_t Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     return fam_atomic_32_swap((int32_t *)((char *)base + offset), value);
 }
@@ -1504,17 +1453,16 @@ uint64_t Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     return fam_atomic_64_swap((int64_t *)((char *)base + offset), value);
 }
@@ -1524,17 +1472,16 @@ float Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     int32_t *buff = reinterpret_cast<int32_t *>(&value);
     int32_t result =
@@ -1548,17 +1495,16 @@ double Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     int64_t *buff = reinterpret_cast<int64_t *>(&value);
     int64_t result =
@@ -1572,16 +1518,15 @@ int32_t Fam_Ops_SHM::atomic_fetch_int32(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     return fam_atomic_32_read((int32_t *)((char *)base + offset));
@@ -1592,16 +1537,15 @@ int64_t Fam_Ops_SHM::atomic_fetch_int64(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     return fam_atomic_64_read((int64_t *)((char *)base + offset));
@@ -1612,16 +1556,15 @@ int128_t Fam_Ops_SHM::atomic_fetch_int128(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int128_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     int128store ResultValueStore;
@@ -1636,16 +1579,15 @@ uint32_t Fam_Ops_SHM::atomic_fetch_uint32(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     return fam_atomic_32_read((int32_t *)((char *)base + offset));
@@ -1656,16 +1598,15 @@ uint64_t Fam_Ops_SHM::atomic_fetch_uint64(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
 
     return fam_atomic_64_read((int64_t *)((char *)base + offset));
@@ -1676,16 +1617,15 @@ float Fam_Ops_SHM::atomic_fetch_float(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     int32_t buff = fam_atomic_32_read((int32_t *)((char *)base + offset));
     float *result = reinterpret_cast<float *>(&buff);
@@ -1697,16 +1637,15 @@ double Fam_Ops_SHM::atomic_fetch_double(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to write into dataitem");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to write into dataitem");
     }
     int64_t buff = fam_atomic_64_read((int64_t *)((char *)base + offset));
     double *result = reinterpret_cast<double *>(&buff);
@@ -1719,17 +1658,16 @@ int32_t Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     return fam_atomic_32_fetch_add((int32_t *)((char *)base + offset), value);
 }
@@ -1740,17 +1678,16 @@ int64_t Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     return fam_atomic_64_fetch_add((int64_t *)((char *)base + offset), value);
 }
@@ -1761,17 +1698,16 @@ uint32_t Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     return fam_atomic_32_fetch_add((int32_t *)((char *)base + offset), value);
 }
@@ -1782,17 +1718,16 @@ uint64_t Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     return fam_atomic_64_fetch_add((int64_t *)((char *)base + offset), value);
 }
@@ -1803,17 +1738,16 @@ float Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_SUM][FLOAT](
@@ -1828,17 +1762,16 @@ double Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_SUM][DOUBLE](
@@ -1882,17 +1815,16 @@ int32_t Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     void *result;
@@ -1907,17 +1839,16 @@ int64_t Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][INT64](
@@ -1931,17 +1862,16 @@ uint32_t Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     void *result;
@@ -1956,17 +1886,16 @@ uint64_t Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][UINT64](
@@ -1980,17 +1909,16 @@ float Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][FLOAT](
@@ -2004,17 +1932,16 @@ double Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     void *result;
@@ -2029,17 +1956,16 @@ int32_t Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     void *result;
@@ -2054,17 +1980,16 @@ int64_t Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][INT64](
@@ -2078,17 +2003,16 @@ uint32_t Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     void *result;
@@ -2103,17 +2027,16 @@ uint64_t Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][UINT64](
@@ -2127,17 +2050,16 @@ float Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][FLOAT](
@@ -2151,17 +2073,16 @@ double Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     void *result;
@@ -2176,17 +2097,16 @@ uint32_t Fam_Ops_SHM::atomic_fetch_and(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
 
     void *result;
@@ -2201,17 +2121,16 @@ uint64_t Fam_Ops_SHM::atomic_fetch_and(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BAND][UINT64](
@@ -2225,17 +2144,16 @@ uint32_t Fam_Ops_SHM::atomic_fetch_or(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BOR][UINT32](
@@ -2249,17 +2167,16 @@ uint64_t Fam_Ops_SHM::atomic_fetch_or(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BOR][UINT64](
@@ -2273,17 +2190,16 @@ uint32_t Fam_Ops_SHM::atomic_fetch_xor(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BXOR][UINT32](
@@ -2297,17 +2213,16 @@ uint64_t Fam_Ops_SHM::atomic_fetch_xor(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
-    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        ERROR_MSG(message, "offset or data size is out of bound");
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_OUTOFRANGE,
+                        "offset or data size is out of bound");
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        ERROR_MSG(message, "not permitted to either read or write, "
-                           "need both read and write permission");
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
+        THROW_ERRNO_MSG(Fam_Datapath_Exception, FAM_ERR_NOPERM,
+                        "not permitted to either read or write, "
+                        "need both read and write permission");
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BXOR][UINT64](

--- a/src/fam-api/fam_ops_shm.cpp
+++ b/src/fam-api/fam_ops_shm.cpp
@@ -38,6 +38,7 @@
 #include <unistd.h>
 
 #include "common/fam_context.h"
+#include "common/fam_internal.h"
 #include "common/fam_ops.h"
 #include "common/fam_ops_shm.h"
 #include "common/fam_util_atomic.h"
@@ -112,7 +113,8 @@ Fam_Context *Fam_Ops_SHM::get_context(Fam_Descriptor *descriptor) {
         (void)pthread_mutex_unlock(&ctxLock);
         return ctx;
     } else {
-        message << "Fam Invalid Option FAM_CONTEXT_MODEL: " << famContextModel;
+        ERROR_MSG(message, "Fam Invalid Option FAM_CONTEXT_MODEL",
+                  famContextModel);
         throw Fam_InvalidOption_Exception(message.str().c_str());
     }
 }
@@ -124,13 +126,15 @@ int Fam_Ops_SHM::put_blocking(void *local, Fam_Descriptor *descriptor,
     uint64_t key = descriptor->get_key();
 
     if ((offset > size) || ((offset + nbytes) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        std::ostringstream message;
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        std::ostringstream message;
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *dest = (void *)((uint64_t)base + offset);
@@ -154,15 +158,16 @@ int Fam_Ops_SHM::get_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + nbytes) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to read from dataitem");
+        ERROR_MSG(message, "not permitted to read from dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *src = (void *)((uint64_t)base + offset);
@@ -187,6 +192,7 @@ int Fam_Ops_SHM::gather_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     void *src;
     void *dest;
@@ -194,13 +200,13 @@ int Fam_Ops_SHM::gather_blocking(void *local, Fam_Descriptor *descriptor,
     if (((firstElement * elementSize) > size) ||
         ((firstElement * elementSize) + elementSize * stride * nElements) >
             size) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to read from dataitem");
+        ERROR_MSG(message, "not permitted to read from dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     Fam_Context *famCtx = get_context(descriptor);
@@ -228,6 +234,7 @@ int Fam_Ops_SHM::gather_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     void *src;
     void *dest;
@@ -239,13 +246,13 @@ int Fam_Ops_SHM::gather_blocking(void *local, Fam_Descriptor *descriptor,
     }
 
     if ((maxOffset > size) || ((maxOffset + elementSize) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to read from dataitem");
+        ERROR_MSG(message, "not permitted to read from dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     Fam_Context *famCtx = get_context(descriptor);
@@ -272,6 +279,7 @@ int Fam_Ops_SHM::scatter_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     void *src;
     void *dest;
@@ -279,13 +287,13 @@ int Fam_Ops_SHM::scatter_blocking(void *local, Fam_Descriptor *descriptor,
     if (((firstElement * elementSize) > size) ||
         ((firstElement * elementSize) + elementSize * stride * nElements) >
             size) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     Fam_Context *famCtx = get_context(descriptor);
@@ -313,6 +321,7 @@ int Fam_Ops_SHM::scatter_blocking(void *local, Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     void *src;
     void *dest;
@@ -324,13 +333,13 @@ int Fam_Ops_SHM::scatter_blocking(void *local, Fam_Descriptor *descriptor,
     }
 
     if ((maxOffset > size) || ((maxOffset + elementSize) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     Fam_Context *famCtx = get_context(descriptor);
@@ -591,18 +600,20 @@ void *Fam_Ops_SHM::copy(Fam_Descriptor *src, uint64_t srcOffset,
     Fam_Region_Item_Info srcInfo = famAllocator->check_permission_get_info(src);
     Fam_Region_Item_Info destInfo =
         famAllocator->check_permission_get_info(dest);
+    std::ostringstream message;
 
     if ((srcOffset > srcInfo.size) || ((srcOffset + nbytes) > srcInfo.size)) {
-        throw Fam_Allocator_Exception(
-            FAM_ERR_OUTOFRANGE,
-            "Source offset or size is beyond dataitem boundary");
+        ERROR_MSG(message, "Source offset or size is beyond dataitem boundary");
+        throw Fam_Allocator_Exception(FAM_ERR_OUTOFRANGE,
+                                      message.str().c_str());
     }
 
     if ((destOffset > destInfo.size) ||
         ((destOffset + nbytes) > destInfo.size)) {
-        throw Fam_Allocator_Exception(
-            FAM_ERR_OUTOFRANGE,
-            "Destination offset or size is beyond dataitem boundary");
+        ERROR_MSG(message,
+                  "Destination offset or size is beyond dataitem boundary");
+        throw Fam_Allocator_Exception(FAM_ERR_OUTOFRANGE,
+                                      message.str().c_str());
     }
 
     Copy_Tag *tag = new Copy_Tag();
@@ -638,15 +649,16 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     fam_atomic_32_write((int32_t *)((char *)base + offset), value);
@@ -657,15 +669,16 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     fam_atomic_64_write((int64_t *)((char *)base + offset), value);
@@ -676,15 +689,16 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int128_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     int128store oldValueStore;
@@ -697,15 +711,16 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     fam_atomic_32_write((int32_t *)((char *)base + offset), value);
@@ -716,15 +731,16 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     fam_atomic_64_write((int64_t *)((char *)base + offset), value);
@@ -735,15 +751,16 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     int32_t *buff = reinterpret_cast<int32_t *>(&value);
     fam_atomic_32_write((int32_t *)((char *)base + offset), *buff);
@@ -754,15 +771,16 @@ void Fam_Ops_SHM::atomic_set(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     int64_t *buff = reinterpret_cast<int64_t *>(&value);
     fam_atomic_64_write((int64_t *)((char *)base + offset), *buff);
@@ -774,15 +792,16 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     fam_atomic_32_fetch_add((int32_t *)((char *)base + offset), value);
 }
@@ -793,15 +812,16 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     fam_atomic_64_fetch_add((int64_t *)((char *)base + offset), value);
 }
@@ -812,15 +832,16 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     fam_atomic_32_fetch_add((int32_t *)((char *)base + offset), value);
 }
@@ -831,15 +852,16 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     fam_atomic_64_fetch_add((int64_t *)((char *)base + offset), value);
 }
@@ -850,15 +872,16 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_SUM][FLOAT](
@@ -871,15 +894,16 @@ void Fam_Ops_SHM::atomic_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_SUM][DOUBLE](
@@ -916,15 +940,16 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -937,15 +962,16 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][INT64](
@@ -957,15 +983,16 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -978,15 +1005,16 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][UINT64](
@@ -998,15 +1026,16 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][FLOAT](
@@ -1018,15 +1047,16 @@ void Fam_Ops_SHM::atomic_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -1039,15 +1069,16 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -1060,16 +1091,18 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
+
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][INT64](
         (void *)((char *)base + offset), (void *)&value, result);
@@ -1080,15 +1113,16 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -1101,15 +1135,16 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][UINT64](
@@ -1121,15 +1156,16 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][FLOAT](
@@ -1141,15 +1177,16 @@ void Fam_Ops_SHM::atomic_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -1162,15 +1199,16 @@ void Fam_Ops_SHM::atomic_and(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -1183,15 +1221,16 @@ void Fam_Ops_SHM::atomic_and(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BAND][UINT64](
@@ -1203,15 +1242,16 @@ void Fam_Ops_SHM::atomic_or(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BOR][UINT32](
@@ -1223,15 +1263,16 @@ void Fam_Ops_SHM::atomic_or(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BOR][UINT64](
@@ -1243,15 +1284,16 @@ void Fam_Ops_SHM::atomic_xor(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BXOR][UINT32](
@@ -1263,15 +1305,16 @@ void Fam_Ops_SHM::atomic_xor(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_WRITE_KEY_SHM) != FAM_WRITE_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BXOR][UINT64](
@@ -1284,15 +1327,16 @@ int32_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     return fam_atomic_32_compare_store((int32_t *)((char *)base + offset),
@@ -1305,16 +1349,17 @@ int64_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     return fam_atomic_64_compare_store((int64_t *)((char *)base + offset),
@@ -1327,16 +1372,17 @@ int128_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int128_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     int128store oldValueStore;
     int128store newValueStore;
@@ -1354,16 +1400,17 @@ uint32_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     return fam_atomic_32_compare_store((int32_t *)((char *)base + offset),
@@ -1375,16 +1422,17 @@ uint64_t Fam_Ops_SHM::compare_swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     return fam_atomic_64_compare_store((int64_t *)((char *)base + offset),
@@ -1396,16 +1444,17 @@ int32_t Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     return fam_atomic_32_swap((int32_t *)((char *)base + offset), value);
 }
@@ -1415,16 +1464,17 @@ int64_t Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     return fam_atomic_64_swap((int64_t *)((char *)base + offset), value);
 }
@@ -1434,16 +1484,17 @@ uint32_t Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     return fam_atomic_32_swap((int32_t *)((char *)base + offset), value);
 }
@@ -1453,16 +1504,17 @@ uint64_t Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     return fam_atomic_64_swap((int64_t *)((char *)base + offset), value);
 }
@@ -1472,16 +1524,17 @@ float Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     int32_t *buff = reinterpret_cast<int32_t *>(&value);
     int32_t result =
@@ -1495,16 +1548,17 @@ double Fam_Ops_SHM::swap(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     int64_t *buff = reinterpret_cast<int64_t *>(&value);
     int64_t result =
@@ -1518,15 +1572,16 @@ int32_t Fam_Ops_SHM::atomic_fetch_int32(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     return fam_atomic_32_read((int32_t *)((char *)base + offset));
@@ -1537,15 +1592,16 @@ int64_t Fam_Ops_SHM::atomic_fetch_int64(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     return fam_atomic_64_read((int64_t *)((char *)base + offset));
@@ -1556,15 +1612,16 @@ int128_t Fam_Ops_SHM::atomic_fetch_int128(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int128_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     int128store ResultValueStore;
@@ -1579,15 +1636,16 @@ uint32_t Fam_Ops_SHM::atomic_fetch_uint32(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     return fam_atomic_32_read((int32_t *)((char *)base + offset));
@@ -1598,15 +1656,16 @@ uint64_t Fam_Ops_SHM::atomic_fetch_uint64(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     return fam_atomic_64_read((int64_t *)((char *)base + offset));
@@ -1617,15 +1676,16 @@ float Fam_Ops_SHM::atomic_fetch_float(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     int32_t buff = fam_atomic_32_read((int32_t *)((char *)base + offset));
     float *result = reinterpret_cast<float *>(&buff);
@@ -1637,15 +1697,16 @@ double Fam_Ops_SHM::atomic_fetch_double(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_READ_KEY_SHM) != FAM_READ_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to write into dataitem");
+        ERROR_MSG(message, "not permitted to write into dataitem");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     int64_t buff = fam_atomic_64_read((int64_t *)((char *)base + offset));
     double *result = reinterpret_cast<double *>(&buff);
@@ -1658,16 +1719,17 @@ int32_t Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     return fam_atomic_32_fetch_add((int32_t *)((char *)base + offset), value);
 }
@@ -1678,16 +1740,17 @@ int64_t Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     return fam_atomic_64_fetch_add((int64_t *)((char *)base + offset), value);
 }
@@ -1698,16 +1761,17 @@ uint32_t Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     return fam_atomic_32_fetch_add((int32_t *)((char *)base + offset), value);
 }
@@ -1718,16 +1782,17 @@ uint64_t Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     return fam_atomic_64_fetch_add((int64_t *)((char *)base + offset), value);
 }
@@ -1738,16 +1803,17 @@ float Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_SUM][FLOAT](
@@ -1762,16 +1828,17 @@ double Fam_Ops_SHM::atomic_fetch_add(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_SUM][DOUBLE](
@@ -1815,16 +1882,17 @@ int32_t Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -1839,16 +1907,17 @@ int64_t Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][INT64](
@@ -1862,16 +1931,17 @@ uint32_t Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -1886,16 +1956,17 @@ uint64_t Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][UINT64](
@@ -1909,16 +1980,17 @@ float Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MIN][FLOAT](
@@ -1932,16 +2004,17 @@ double Fam_Ops_SHM::atomic_fetch_min(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -1956,16 +2029,17 @@ int32_t Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -1980,16 +2054,17 @@ int64_t Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(int64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][INT64](
@@ -2003,16 +2078,17 @@ uint32_t Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -2027,16 +2103,17 @@ uint64_t Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][UINT64](
@@ -2050,16 +2127,17 @@ float Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(float)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_MAX][FLOAT](
@@ -2073,16 +2151,17 @@ double Fam_Ops_SHM::atomic_fetch_max(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(double)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -2097,16 +2176,17 @@ uint32_t Fam_Ops_SHM::atomic_fetch_and(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
 
     void *result;
@@ -2121,16 +2201,17 @@ uint64_t Fam_Ops_SHM::atomic_fetch_and(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BAND][UINT64](
@@ -2144,16 +2225,17 @@ uint32_t Fam_Ops_SHM::atomic_fetch_or(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BOR][UINT32](
@@ -2167,16 +2249,17 @@ uint64_t Fam_Ops_SHM::atomic_fetch_or(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BOR][UINT64](
@@ -2190,16 +2273,17 @@ uint32_t Fam_Ops_SHM::atomic_fetch_xor(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint32_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BXOR][UINT32](
@@ -2213,16 +2297,17 @@ uint64_t Fam_Ops_SHM::atomic_fetch_xor(Fam_Descriptor *descriptor,
     void *base = descriptor->get_base_address();
     uint64_t size = descriptor->get_size();
     uint64_t key = descriptor->get_key();
+    std::ostringstream message;
 
     if ((offset > size) || ((offset + sizeof(uint64_t)) > size)) {
-        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE,
-                                     "offset or data size is out of bound");
+        ERROR_MSG(message, "offset or data size is out of bound");
+        throw Fam_Datapath_Exception(FAM_ERR_OUTOFRANGE, message.str().c_str());
     }
 
     if ((key & FAM_RW_KEY_SHM) != FAM_RW_KEY_SHM) {
-        throw Fam_Datapath_Exception(FAM_ERR_NOPERM,
-                                     "not permitted to either read or write, "
-                                     "need both read and write permission");
+        ERROR_MSG(message, "not permitted to either read or write, "
+                           "need both read and write permission");
+        throw Fam_Datapath_Exception(FAM_ERR_NOPERM, message.str().c_str());
     }
     void *result;
     fam_atomic_readwrite_handlers[FAM_BXOR][UINT64](

--- a/test/apps/pagerank/pagerank_common.h
+++ b/test/apps/pagerank/pagerank_common.h
@@ -176,13 +176,8 @@ void *spmv_malloc(uint64_t size) {
 
 int spmv_fam_read(char *buf, Fam_Descriptor *dataitem, uint64_t offset,
                   uint64_t size) {
-    int ret;
     try {
-        ret = my_fam->fam_get_blocking(buf, dataitem, offset, size);
-        if (ret < 0) {
-            fam_stream << "fam_get failed" << endl;
-            return -1;
-        }
+        my_fam->fam_get_blocking(buf, dataitem, offset, size);
     }
     catch (Fam_Exception &e) {
         cout << "FAM Exception caught" << endl;
@@ -246,7 +241,6 @@ Fam_Descriptor *spmv_get_dataitem(const char *dataitemName) {
 int spmv_fam_write(char *inpBuf, const char *dataitemName, uint64_t offset,
                    uint64_t size) {
     Fam_Descriptor *dataitem = NULL;
-    int ret;
 
     // Lookup config dataitem
     try {
@@ -259,11 +253,7 @@ int spmv_fam_write(char *inpBuf, const char *dataitemName, uint64_t offset,
         return -1;
     }
     try {
-        ret = my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
-        if (ret < 0) {
-            fam_stream << "fam_put failed" << endl;
-            exit(1);
-        }
+        my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
     }
     catch (Fam_Exception &e) {
         fam_stream << "Exception caught" << endl;
@@ -276,14 +266,8 @@ int spmv_fam_write(char *inpBuf, const char *dataitemName, uint64_t offset,
 
 int spmv_fam_write(char *inpBuf, Fam_Descriptor *dataitem, uint64_t offset,
                    uint64_t size) {
-    int ret;
-
     try {
-        ret = my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
-        if (ret < 0) {
-            fam_stream << "fam_put failed" << endl;
-            exit(1);
-        }
+        my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
     }
     catch (Fam_Exception &e) {
         fam_stream << "Exception caught" << endl;

--- a/test/apps/spmv/csr_perload.cpp
+++ b/test/apps/spmv/csr_perload.cpp
@@ -127,14 +127,8 @@ void spmv_read_config_file(char *configFilename, int &matRowCount,
 
 int spmv_fam_write(char *inpBuf, Fam_Descriptor *dataitem, uint64_t offset,
                    uint64_t size) {
-    int ret;
-
     try {
-        ret = my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
-        if (ret < 0) {
-            cout << "fam_put failed" << endl;
-            exit(1);
-        }
+        my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;

--- a/test/apps/spmv/fam_spmv_multi_atomic.cpp
+++ b/test/apps/spmv/fam_spmv_multi_atomic.cpp
@@ -88,13 +88,8 @@ void *spmv_malloc(uint64_t size) {
 }
 int spmv_fam_read(char *buf, Fam_Descriptor *dataitem, uint64_t offset,
                   uint64_t size) {
-    int ret;
     try {
-        ret = my_fam->fam_get_blocking(buf, dataitem, offset, size);
-        if (ret < 0) {
-            fam_stream << "fam_get failed" << endl;
-            return -1;
-        }
+        my_fam->fam_get_blocking(buf, dataitem, offset, size);
     } catch (...) {
         fam_stream << "fam get failed" << endl;
         return -1;
@@ -134,7 +129,6 @@ int spmv_fam_read(char *buf, const char *dataitemName, uint64_t offset,
 int spmv_fam_write(char *inpBuf, const char *dataitemName, uint64_t offset,
                    uint64_t size) {
     Fam_Descriptor *dataitem = NULL;
-    int ret;
 
     // Lookup config dataitem
     try {
@@ -146,11 +140,7 @@ int spmv_fam_write(char *inpBuf, const char *dataitemName, uint64_t offset,
         return -1;
     }
     try {
-        ret = my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
-        if (ret < 0) {
-            fam_stream << "fam_put failed" << endl;
-            exit(1);
-        }
+        my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
     } catch (Fam_Exception &e) {
         fam_stream << "Exception caught" << endl;
         fam_stream << "Error msg: " << e.fam_error_msg() << endl;
@@ -161,14 +151,8 @@ int spmv_fam_write(char *inpBuf, const char *dataitemName, uint64_t offset,
 }
 int spmv_fam_write(char *inpBuf, Fam_Descriptor *dataitem, uint64_t offset,
                    uint64_t size) {
-    int ret;
-
     try {
-        ret = my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
-        if (ret < 0) {
-            fam_stream << "fam_put failed" << endl;
-            exit(1);
-        }
+        my_fam->fam_put_blocking(inpBuf, dataitem, offset, size);
     } catch (Fam_Exception &e) {
         fam_stream << "Exception caught" << endl;
         fam_stream << "Error msg: " << e.fam_error_msg() << endl;

--- a/test/maxconfig/fam-api-maxconfig/fam_mm_maxconfig_test.cpp
+++ b/test/maxconfig/fam-api-maxconfig/fam_mm_maxconfig_test.cpp
@@ -62,7 +62,7 @@ TEST(FamMMNegativeTest, FamCreateRegionGreaterMaxSizeFailure) {
 
     EXPECT_THROW(
         my_fam->fam_create_region(testRegion, 2199023255552, 0777, RAID1),
-        Fam_Allocator_Exception);
+        Fam_Exception);
     free((void *)testRegion);
 }
 
@@ -96,7 +96,7 @@ TEST(FamMMNegativeTest, FamAllocateGreaterMaxSizeFailure) {
                                                      0777, RAID1));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_THROW(my_fam->fam_allocate(dataItem, 824633720832, 0444, desc),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
     delete desc;
     free((void *)testRegion);

--- a/test/reg-test/allocator-reg/fam_resize_reg_test.cpp
+++ b/test/reg-test/allocator-reg/fam_resize_reg_test.cpp
@@ -239,7 +239,7 @@ TEST(FamResize, MultiPeAllocationResizeSuccess) {
 
         EXPECT_THROW(item2 =
                          my_fam->fam_allocate(secondItem, 524288, 0777, desc),
-                     Fam_Allocator_Exception);
+                     Fam_Exception);
     }
 
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -286,8 +286,7 @@ TEST(FamResize, ResizeNoPerm) {
     EXPECT_NE((void *)NULL, desc);
 
     // Resizing the region
-    EXPECT_THROW(my_fam->fam_resize_region(desc, 16384),
-                 Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_resize_region(desc, 16384), Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
 

--- a/test/reg-test/fam-api-reg/fam_initialize_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_initialize_reg_test.cpp
@@ -55,8 +55,7 @@ TEST(FamInitialize, InitializeSuccess) {
 
 // Test case#2 initialize with NULL parametes.
 TEST(FamInitialize, InitializeNullTest) {
-    EXPECT_THROW(my_fam->fam_initialize(NULL, NULL),
-                 Fam_InvalidOption_Exception);
+    EXPECT_THROW(my_fam->fam_initialize(NULL, NULL), Fam_Exception);
     EXPECT_NO_THROW(my_fam->fam_finalize(NULL));
 }
 int main(int argc, char **argv) {

--- a/test/reg-test/fam-api-reg/fam_invalid_offset_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_invalid_offset_reg_test.cpp
@@ -60,7 +60,7 @@ TEST(FamInvalidOffset, InvalidOffsetSuccess) {
     EXPECT_NE((void *)NULL, item);
 
     EXPECT_THROW(my_fam->fam_put_blocking(local, item, 2000, 13),
-                 Fam_Datapath_Exception);
+                 Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));

--- a/test/reg-test/fam-api-reg/fam_invalidkey_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_invalidkey_reg_test.cpp
@@ -82,7 +82,7 @@ TEST(FamInvalidKey, InvalidKeySuccess) {
     EXPECT_THROW(fabric_write(invalidKey, message, 25, 0,
                               (*famOps->get_fiAddrs())[nodeId],
                               famOps->get_defaultCtx(item)),
-                 Fam_Datapath_Exception);
+                 Fam_Exception);
 
     char *buff = (char *)malloc(1024);
     memset(buff, 0, 1024);
@@ -90,7 +90,7 @@ TEST(FamInvalidKey, InvalidKeySuccess) {
     EXPECT_THROW(fabric_read(invalidKey, buff, 25, 0,
                              (*famOps->get_fiAddrs())[nodeId],
                              famOps->get_defaultCtx(item)),
-                 Fam_Datapath_Exception);
+                 Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));

--- a/test/reg-test/fam-api-reg/fam_logical_atomic_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_logical_atomic_reg_test.cpp
@@ -412,71 +412,71 @@ TEST(FamLogicalAtomics, NonfetchLogicalNegativePerm) {
             // uint32 operations
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_and(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_or(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_xor(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             // uint64 operations
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_and(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_or(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_xor(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #else
             // uint32 operations
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_and(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_or(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_xor(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             // uint64 operations
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_and(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_or(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_xor(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
         }
 
@@ -518,48 +518,48 @@ TEST(FamLogicalAtomics, FetchLogicalNegativePerm) {
             // uint32 operations
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             // uint32 operations
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_and(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_fetch_or(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_fetch_xor(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             // uint32 operations
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             // uint64 operations
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
 
             EXPECT_THROW(
                 my_fam->fam_fetch_and(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_fetch_or(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_fetch_xor(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
         }
 
         EXPECT_NO_THROW(my_fam->fam_deallocate(item));
@@ -600,70 +600,70 @@ TEST(FamLogicalAtomics, NonfetchLogicalNegativeInvalidOffset) {
             // uint32 operations
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_and(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_or(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_xor(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             // uint64 operations
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_and(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_or(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_xor(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             // uint32 operations
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_and(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_or(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_xor(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             // uint64 operations
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_and(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_or(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_xor(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
         }
 
@@ -705,49 +705,49 @@ TEST(FamLogicalAtomics, FetchLogicalNegativeInvalidOffset) {
             // uint32 operations
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             // uint32 operations
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
 
             EXPECT_THROW(
                 my_fam->fam_fetch_and(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_fetch_or(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_fetch_xor(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             // uint32 operations
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             // uint64 operations
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
 
             EXPECT_THROW(
                 my_fam->fam_fetch_and(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_fetch_or(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_fetch_xor(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
         }
 
         EXPECT_NO_THROW(my_fam->fam_deallocate(item));

--- a/test/reg-test/fam-api-reg/fam_min_max_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_min_max_atomics_mt_reg_test.cpp
@@ -810,98 +810,98 @@ void *thrd_min_max_inv_perms(void *arg) {
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandInt32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandInt32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
 #endif
            EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandInt64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandInt64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandFloat[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandFloat[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandDouble[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandDouble[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
     pthread_exit(NULL);
 }	    
@@ -956,124 +956,124 @@ void *thrd_min_max_inv_perms2(void *arg) {
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandInt32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandInt64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandFloat[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandDouble[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandInt32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandInt32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandInt32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandInt64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandInt64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandInt64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandFloat[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandFloat[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandFloat[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandDouble[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandDouble[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandDouble[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
 
     pthread_exit(NULL);
@@ -1127,123 +1127,123 @@ void *thrd_min_max_inv_offset(void *arg) {
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandInt32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandInt64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandFloat[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandDouble[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, offset, operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, offset, operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandInt32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandInt32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandInt32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandInt64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandInt64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandInt64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandFloat[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandFloat[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandFloat[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandDouble[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, offset, operandDouble[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, offset, operandDouble[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
 
     pthread_exit(NULL);
@@ -1299,98 +1299,98 @@ void *thrd_min_max_inv_offset2(void *arg) {
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandInt32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandInt32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandInt64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandInt64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandFloat[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandFloat[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, offset, operandDouble[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, offset, operandDouble[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, offset, operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, offset, operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
     pthread_exit(NULL);
 }	    
 

--- a/test/reg-test/fam-api-reg/fam_min_max_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_min_max_atomics_reg_test.cpp
@@ -789,96 +789,96 @@ TEST(FamMinMaxAtomics, MinMaxNegativeBlockPerm) {
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandFloat[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandFloat[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandDouble[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandDouble[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
         }
 
         EXPECT_NO_THROW(my_fam->fam_deallocate(item));
@@ -917,124 +917,124 @@ TEST(FamMinMaxAtomics, MinMaxNegativeNonblockPerm) {
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandFloat[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandDouble[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandInt32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandInt32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandInt64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandInt64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandFloat[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandFloat[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandFloat[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandDouble[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandDouble[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandDouble[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
         }
 
@@ -1074,123 +1074,123 @@ TEST(FamMinMaxAtomics, MinMaxNegativeNonblockInvalidOffset) {
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandFloat[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandDouble[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandInt32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandInt32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandUint32[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandInt64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandInt64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandUint64[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandFloat[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandFloat[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandFloat[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandDouble[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_min(item, testOffset[ofs], operandDouble[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
             EXPECT_NO_THROW(
                 my_fam->fam_max(item, testOffset[ofs], operandDouble[1]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
         }
 
@@ -1230,98 +1230,98 @@ TEST(FamMinMaxAtomics, MinMaxNegativeBlockInvalidOffset) {
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandInt32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint32[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandUint32[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandInt64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandInt64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandUint64[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandUint64[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandFloat[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandFloat[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandFloat[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 
 #ifdef SHM
             EXPECT_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandDouble[0]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
 #else
             EXPECT_NO_THROW(
                 my_fam->fam_set(item, testOffset[ofs], operandDouble[0]));
-            EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+            EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 #endif
             EXPECT_THROW(
                 my_fam->fam_fetch_min(item, testOffset[ofs], operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
             EXPECT_THROW(
                 my_fam->fam_fetch_max(item, testOffset[ofs], operandDouble[1]),
-                Fam_Datapath_Exception);
+                Fam_Exception);
         }
 
         EXPECT_NO_THROW(my_fam->fam_deallocate(item));

--- a/test/reg-test/fam-api-reg/fam_mm_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_mm_reg_test.cpp
@@ -110,11 +110,11 @@ TEST(FamMMTest, FamAllocateSameSuccess) {
     EXPECT_NO_THROW(item = my_fam->fam_allocate(dataItem, 1024, 0777, desc));
     EXPECT_NE((void *)NULL, item);
     EXPECT_THROW(item = my_fam->fam_allocate(dataItem, 512, 0777, desc),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
     EXPECT_THROW(item = my_fam->fam_allocate(dataItem, 1024, 0444, desc),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
     EXPECT_THROW(item = my_fam->fam_allocate(dataItem, 1024, 0777, desc),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
@@ -159,13 +159,13 @@ TEST(FamMMTest, FamCreateSameRegionDestroysSuccess) {
 
     EXPECT_THROW(desc =
                      my_fam->fam_create_region(testRegion, 4096, 0777, RAID1),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
     EXPECT_THROW(desc =
                      my_fam->fam_create_region(testRegion, 1024, 0777, RAID1),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
     EXPECT_THROW(desc =
                      my_fam->fam_create_region(testRegion, 4096, 0444, RAID1),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
     delete desc;
@@ -217,7 +217,7 @@ TEST(FamMMNegativeTest, FamCreateGreaterBignameRegionFailure) {
         get_uniq_str("testtesttesttesttesttesttesttesttesttest", my_fam);
 
     EXPECT_THROW(my_fam->fam_create_region(testRegion, 4096, 0777, RAID1),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
 }
 
 TEST(FamMMTest, FamCreateBignameRegionDestroySuccess) {

--- a/test/reg-test/fam-api-reg/fam_noperm_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_noperm_reg_test.cpp
@@ -59,8 +59,7 @@ TEST(FamNoPerm, NoPermSuccess) {
     EXPECT_NO_THROW(item = my_fam->fam_allocate(firstItem, 1024, 0444, desc));
     EXPECT_NE((void *)NULL, item);
 
-    EXPECT_THROW(my_fam->fam_put_blocking(local, item, 0, 13),
-                 Fam_Datapath_Exception);
+    EXPECT_THROW(my_fam->fam_put_blocking(local, item, 0, 13), Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));

--- a/test/reg-test/fam-api-reg/fam_options_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_options_reg_test.cpp
@@ -99,7 +99,7 @@ TEST(FamOption, QueryWithInavlidOption) {
     char *opt;
 
     opt = strdup("NotAnOption");
-    EXPECT_THROW(my_fam->fam_get_option(opt), Fam_InvalidOption_Exception);
+    EXPECT_THROW(my_fam->fam_get_option(opt), Fam_Exception);
     free(opt);
 }
 

--- a/test/reg-test/fam-api-reg/fam_put_get_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_get_mt_reg_test.cpp
@@ -426,7 +426,7 @@ void *thr_func5_no_put(void *arg) {
     // Put blocking
     EXPECT_THROW(
         my_fam->fam_put_blocking(local, items[msg_no], (uint64_t)off, MSG_SIZE),
-        Fam_Datapath_Exception);
+        Fam_Exception);
 
     free(local);
     free((void *)dataItem);
@@ -503,7 +503,7 @@ void *thr_func6_get(void *arg) {
     sleep(1);
     EXPECT_THROW(my_fam->fam_get_blocking(local2, items[msg_no], (uint64_t)off,
                                           MSG_SIZE),
-                 Fam_Datapath_Exception);
+                 Fam_Exception);
     free(local);
     free(local2);
     pthread_exit(NULL);

--- a/test/reg-test/fam-api-reg/fam_put_get_negative_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_get_negative_test.cpp
@@ -63,11 +63,10 @@ TEST(FamPutGetT, PutGetFail) {
     char *local2 = (char *)malloc(20);
 
     // No write perm
-    EXPECT_THROW(my_fam->fam_put_blocking(local, item, 0, 13),
-                 Fam_Datapath_Exception);
+    EXPECT_THROW(my_fam->fam_put_blocking(local, item, 0, 13), Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_put_nonblocking(local, item, 0, 13));
-    EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+    EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
     // No read permission
     EXPECT_NO_THROW(my_fam->fam_change_permissions(item, 0333));
@@ -82,55 +81,45 @@ TEST(FamPutGetT, PutGetFail) {
 
     // write to invalid offset bigger than alloc size
     EXPECT_THROW(my_fam->fam_put_blocking(local, item, 2048, 13),
-                 Fam_Datapath_Exception);
+                 Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_put_nonblocking(local, item, 2048, 13));
-    EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+    EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
     // Read from offset bigger than alloc size
     EXPECT_THROW(my_fam->fam_get_blocking(local2, item, 2048, 13),
-                 Fam_Datapath_Exception);
+                 Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_get_nonblocking(local2, item, 2048, 13));
-    EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+    EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
     char *local3 = (char *)malloc(8192);
 
     // Read size bigger than alloc size
     EXPECT_THROW(my_fam->fam_get_blocking(local3, item, 0, 8192),
-                 Fam_Datapath_Exception);
+                 Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_get_nonblocking(local3, item, 0, 8192));
-    EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+    EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
     // Pass invalid option
-    EXPECT_THROW(my_fam->fam_put_blocking(NULL, item, 0, 13),
-                 Fam_InvalidOption_Exception);
-    EXPECT_THROW(my_fam->fam_put_blocking(local, NULL, 0, 13),
-                 Fam_InvalidOption_Exception);
-    EXPECT_THROW(my_fam->fam_get_blocking(NULL, item, 0, 13),
-                 Fam_InvalidOption_Exception);
-    EXPECT_THROW(my_fam->fam_get_blocking(local2, NULL, 0, 13),
-                 Fam_InvalidOption_Exception);
+    EXPECT_THROW(my_fam->fam_put_blocking(NULL, item, 0, 13), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_put_blocking(local, NULL, 0, 13), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_get_blocking(NULL, item, 0, 13), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_get_blocking(local2, NULL, 0, 13), Fam_Exception);
 
-    EXPECT_THROW(my_fam->fam_put_nonblocking(NULL, item, 0, 13),
-                 Fam_InvalidOption_Exception);
+    EXPECT_THROW(my_fam->fam_put_nonblocking(NULL, item, 0, 13), Fam_Exception);
     EXPECT_THROW(my_fam->fam_put_nonblocking(local, NULL, 0, 13),
-                 Fam_InvalidOption_Exception);
-    EXPECT_THROW(my_fam->fam_get_nonblocking(NULL, item, 0, 13),
-                 Fam_InvalidOption_Exception);
+                 Fam_Exception);
+    EXPECT_THROW(my_fam->fam_get_nonblocking(NULL, item, 0, 13), Fam_Exception);
     EXPECT_THROW(my_fam->fam_get_nonblocking(local2, NULL, 0, 13),
-                 Fam_InvalidOption_Exception);
+                 Fam_Exception);
 
     // Pass 0 as nbytes
-    EXPECT_THROW(my_fam->fam_put_blocking(local, item, 0, 0),
-                 Fam_InvalidOption_Exception);
-    EXPECT_THROW(my_fam->fam_get_blocking(local, item, 0, 0),
-                 Fam_InvalidOption_Exception);
-    EXPECT_THROW(my_fam->fam_put_nonblocking(local, item, 0, 0),
-                 Fam_InvalidOption_Exception);
-    EXPECT_THROW(my_fam->fam_get_nonblocking(local, item, 0, 0),
-                 Fam_InvalidOption_Exception);
+    EXPECT_THROW(my_fam->fam_put_blocking(local, item, 0, 0), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_get_blocking(local, item, 0, 0), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_put_nonblocking(local, item, 0, 0), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_get_nonblocking(local, item, 0, 0), Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
 
@@ -169,11 +158,11 @@ TEST(FamPutGetT, ScatterGatherIndexFail) {
     // No write perm
     EXPECT_THROW(
         my_fam->fam_scatter_blocking(newLocal, item, 5, indexes, sizeof(int)),
-        Fam_Datapath_Exception);
+        Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_scatter_nonblocking(newLocal, item, 5, indexes,
                                                     sizeof(int)));
-    EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+    EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
     // No read permission
     EXPECT_NO_THROW(my_fam->fam_change_permissions(item, 0333));
@@ -190,52 +179,52 @@ TEST(FamPutGetT, ScatterGatherIndexFail) {
     // Pass invalid option
     EXPECT_THROW(
         my_fam->fam_gather_blocking(NULL, item, 5, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_gather_nonblocking(NULL, item, 5, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_scatter_blocking(NULL, item, 5, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_scatter_nonblocking(NULL, item, 5, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_gather_blocking(local2, NULL, 5, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_gather_nonblocking(local2, NULL, 5, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_scatter_blocking(newLocal, NULL, 5, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(my_fam->fam_scatter_nonblocking(newLocal, NULL, 5, indexes,
                                                  sizeof(int)),
-                 Fam_InvalidOption_Exception);
+                 Fam_Exception);
 
     // Pass 0 as nelements
     EXPECT_THROW(
         my_fam->fam_gather_blocking(local2, item, 0, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_gather_nonblocking(local2, item, 0, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_scatter_blocking(newLocal, item, 0, indexes, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(my_fam->fam_scatter_nonblocking(newLocal, item, 0, indexes,
                                                  sizeof(int)),
-                 Fam_InvalidOption_Exception);
+                 Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
 
@@ -272,11 +261,11 @@ TEST(FamPutGetT, ScatterGatherStrideFail) {
     // No write perm
     EXPECT_THROW(
         my_fam->fam_scatter_blocking(newLocal, item, 5, 2, 3, sizeof(int)),
-        Fam_Datapath_Exception);
+        Fam_Exception);
 
     EXPECT_NO_THROW(
         my_fam->fam_scatter_nonblocking(newLocal, item, 5, 2, 3, sizeof(int)));
-    EXPECT_THROW(my_fam->fam_quiet(), Fam_Datapath_Exception);
+    EXPECT_THROW(my_fam->fam_quiet(), Fam_Exception);
 
     // No read permission
     EXPECT_NO_THROW(my_fam->fam_change_permissions(item, 0333));
@@ -292,51 +281,51 @@ TEST(FamPutGetT, ScatterGatherStrideFail) {
 
     // Pass invalid option
     EXPECT_THROW(my_fam->fam_gather_blocking(NULL, item, 5, 2, 3, sizeof(int)),
-                 Fam_InvalidOption_Exception);
+                 Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_gather_nonblocking(NULL, item, 5, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(my_fam->fam_scatter_blocking(NULL, item, 5, 2, 3, sizeof(int)),
-                 Fam_InvalidOption_Exception);
+                 Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_scatter_nonblocking(NULL, item, 5, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_gather_blocking(local2, NULL, 5, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_gather_nonblocking(local2, NULL, 5, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_scatter_blocking(newLocal, NULL, 5, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_scatter_nonblocking(newLocal, NULL, 5, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     // Pass 0 as nelements
     EXPECT_THROW(
         my_fam->fam_gather_blocking(local2, item, 0, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_gather_nonblocking(local2, item, 0, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_scatter_blocking(newLocal, item, 0, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_THROW(
         my_fam->fam_scatter_nonblocking(newLocal, item, 0, 2, 3, sizeof(int)),
-        Fam_InvalidOption_Exception);
+        Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
 

--- a/test/reg-test/fam-api-reg/fam_scatter_gather_blocking_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_scatter_gather_blocking_mt_reg_test.cpp
@@ -109,7 +109,7 @@ void *thr_func_index_expect_failure(void *arg) {
     uint64_t indexes[] = {0, 7, 3, 5, 8, 1, 2, 4, 6, 9};
     EXPECT_THROW(
         my_fam->fam_scatter_blocking(newLocal, item, 10, indexes, sizeof(int)),
-        Fam_Datapath_Exception);
+        Fam_Exception);
 
     int *local2 = (int *)malloc(10 * sizeof(int));
 
@@ -128,7 +128,7 @@ void *thr_func_stride_expect_failure(void *arg) {
 
     EXPECT_THROW(
         my_fam->fam_scatter_blocking(newLocal, item, 5, 2, 3, sizeof(int)),
-        Fam_Datapath_Exception);
+        Fam_Exception);
 
     int *local2 = (int *)malloc(10 * sizeof(int));
 

--- a/test/reg-test/fam-api-reg/fam_stat_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_stat_reg_test.cpp
@@ -263,11 +263,11 @@ TEST(FamStat, FamStatFailure) {
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
 
-    EXPECT_THROW(my_fam->fam_deallocate(item1), Fam_Allocator_Exception);
-    EXPECT_THROW(my_fam->fam_destroy_region(desc1), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_deallocate(item1), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_destroy_region(desc1), Fam_Exception);
 
-    EXPECT_THROW(my_fam->fam_deallocate(item2), Fam_Allocator_Exception);
-    EXPECT_THROW(my_fam->fam_destroy_region(desc2), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_deallocate(item2), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_destroy_region(desc2), Fam_Exception);
 
     EXPECT_THROW(my_fam->fam_stat((Fam_Region_Descriptor *)desc, info),
                  Fam_Exception);

--- a/test/reg-test/fam-api-reg/fam_stat_reg_test_shm.cpp
+++ b/test/reg-test/fam-api-reg/fam_stat_reg_test_shm.cpp
@@ -263,11 +263,11 @@ TEST(FamStat, FamStatFailure) {
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
 
-    EXPECT_THROW(my_fam->fam_deallocate(item1), Fam_Allocator_Exception);
-    EXPECT_THROW(my_fam->fam_destroy_region(desc1), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_deallocate(item1), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_destroy_region(desc1), Fam_Exception);
 
-    EXPECT_THROW(my_fam->fam_deallocate(item2), Fam_Allocator_Exception);
-    EXPECT_THROW(my_fam->fam_destroy_region(desc2), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_deallocate(item2), Fam_Exception);
+    EXPECT_THROW(my_fam->fam_destroy_region(desc2), Fam_Exception);
 
     EXPECT_THROW(my_fam->fam_stat((Fam_Region_Descriptor *)desc, info),
                  Fam_Exception);

--- a/test/reg-test/metadata-reg/fam_metadata_reg_test.cpp
+++ b/test/reg-test/metadata-reg/fam_metadata_reg_test.cpp
@@ -153,7 +153,7 @@ TEST(FamMetadata, RegionFail) {
 
     EXPECT_THROW(
         my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1),
-        Fam_Allocator_Exception);
+        Fam_Exception);
 
     regionId = node.regionId;
 
@@ -186,7 +186,7 @@ TEST(FamMetadata, RegionFail) {
     EXPECT_EQ(META_KEY_DOES_NOT_EXIST,
               manager->metadata_delete_region(testRegion));
 
-    EXPECT_THROW(my_fam->fam_destroy_region(desc), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_destroy_region(desc), Fam_Exception);
 
     EXPECT_EQ(META_NO_ERROR,
               manager->metadata_insert_region(regionId, testRegion, regnode));
@@ -326,7 +326,7 @@ TEST(FamMetadata, DataitemFail) {
     EXPECT_NE((void *)NULL, item);
 
     EXPECT_THROW(my_fam->fam_allocate(firstItem, 1024, 0777, desc),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
 
     EXPECT_EQ(META_NO_ERROR,
               manager->metadata_find_dataitem(firstItem, regionId, dinode));
@@ -415,7 +415,7 @@ TEST(FamMetadata, DataitemFail) {
     EXPECT_EQ(META_NO_ERROR,
               manager->metadata_delete_dataitem(dataitemId, testRegion));
 
-    EXPECT_THROW(my_fam->fam_deallocate(item), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_deallocate(item), Fam_Exception);
 
     EXPECT_EQ(META_NO_ERROR, manager->metadata_insert_dataitem(
                                  dataitemId, regionId, datanode, firstItem));
@@ -424,7 +424,7 @@ TEST(FamMetadata, DataitemFail) {
 
     EXPECT_EQ(META_NO_ERROR, manager->metadata_delete_region(testRegion));
 
-    EXPECT_THROW(my_fam->fam_destroy_region(desc), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_destroy_region(desc), Fam_Exception);
 
     EXPECT_EQ(META_NO_ERROR,
               manager->metadata_insert_region(regionId, testRegion, regnode));

--- a/test/unit-test/allocator/fam_allocator_test.cpp
+++ b/test/unit-test/allocator/fam_allocator_test.cpp
@@ -55,8 +55,6 @@ int main() {
     fam_opts.memoryServer = strdup(TEST_MEMORY_SERVER);
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    fam_opts.allocator = strdup("NVMM");
-    fam_opts.runtime = strdup("NONE");
     try {
         my_fam->fam_initialize("default", &fam_opts);
     } catch (Fam_Exception &e) {

--- a/test/unit-test/allocator/fam_allocator_test.cpp
+++ b/test/unit-test/allocator/fam_allocator_test.cpp
@@ -55,11 +55,13 @@ int main() {
     fam_opts.memoryServer = strdup(TEST_MEMORY_SERVER);
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    fam_opts.allocator = strdup("NVMM");
+    fam_opts.runtime = strdup("NONE");
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     // Create Region

--- a/test/unit-test/allocator/fam_allocator_test_nvmm.cpp
+++ b/test/unit-test/allocator/fam_allocator_test_nvmm.cpp
@@ -77,11 +77,11 @@ int main() {
 
     // Initialize openFAM API
     fam_opts.allocator = strdup("NVMM");
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     // Create Region
@@ -97,7 +97,9 @@ int main() {
     }
 
     // Change the permission of region
-    if (my_fam->fam_change_permissions(desc, 0777) < 0) {
+    try {
+        my_fam->fam_change_permissions(desc, 0777);
+    } catch (Fam_Exception &e) {
         cout << "fam change region permission failed" << endl;
         my_fam->fam_destroy_region(desc);
         exit(1);
@@ -125,12 +127,14 @@ int main() {
         // We are expecting an exception here.
         my_fam->fam_destroy_region(desc);
         exit(1);
-    } catch (Fam_InvalidOption_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam_map needs write permission" << endl;
     }
 
     // Change the permission of dataitem
-    if (my_fam->fam_change_permissions(item, 0777) < 0) {
+    try {
+        my_fam->fam_change_permissions(item, 0777);
+    } catch (Fam_Exception &e) {
         cout << "fam change region permission failed" << endl;
         my_fam->fam_destroy_region(desc);
         exit(1);

--- a/test/unit-test/allocator/fam_invalidkey_test.cpp
+++ b/test/unit-test/allocator/fam_invalidkey_test.cpp
@@ -72,11 +72,11 @@ int main() {
     // Initialize openFAM API
     fam_opts.memoryServer = strdup(TEST_MEMORY_SERVER);
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     // Create Region

--- a/test/unit-test/fam-api/fam_allocate_map_nvmm.cpp
+++ b/test/unit-test/fam-api/fam_allocate_map_nvmm.cpp
@@ -49,11 +49,11 @@ int main() {
 
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
     cout << " Calling fam_initialize" << endl;
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     try {

--- a/test/unit-test/fam-api/fam_compare_swap_atomics_128_mt.cpp
+++ b/test/unit-test/fam-api/fam_compare_swap_atomics_128_mt.cpp
@@ -66,8 +66,7 @@ void *thr_func(void *arg) {
     try {
         retValueInt128.i128 = my_fam->fam_compare_swap(
             item, 0, oldValueInt128.i128, newValueInt128.i128);
-    }
-    catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -108,11 +107,11 @@ int main() {
     fam_opts.memoryServer = strdup(TEST_MEMORY_SERVER);
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -134,16 +133,14 @@ int main() {
 
     try {
         my_fam->fam_set(item, 0, valueInt128.i64[0]);
-    }
-    catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
     }
     try {
         my_fam->fam_set(item, sizeof(uint64_t), valueInt128.i64[1]);
-    }
-    catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_compare_swap_atomics_nvmm_test.cpp
+++ b/test/unit-test/fam-api/fam_compare_swap_atomics_nvmm_test.cpp
@@ -62,11 +62,11 @@ int main() {
 
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
 
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -87,7 +87,7 @@ int main() {
     int32_t valueInt32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 4, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -98,7 +98,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 4, oldValueInt32, newValueInt32);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -106,7 +106,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_int32(item, 4);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -117,7 +117,7 @@ int main() {
     int64_t valueInt64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 4, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -128,7 +128,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 4, oldValueInt64, newValueInt64);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -136,7 +136,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_int64(item, 4);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -147,7 +147,7 @@ int main() {
     uint32_t valueUint32 = 0xBBBBBBBB;
     try {
         my_fam->fam_set(item, 4, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -158,7 +158,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 4, oldValueUint32, newValueUint32);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -166,7 +166,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 4);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -177,7 +177,7 @@ int main() {
     uint64_t valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 4, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -188,7 +188,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 4, oldValueUint64, newValueUint64);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -196,7 +196,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 4);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -207,7 +207,7 @@ int main() {
     valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 4, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -218,7 +218,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 4, oldValueUint64, newValueUint64);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -226,7 +226,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 4);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -252,7 +252,7 @@ int main() {
 
     try {
         my_fam->fam_set(item, 0, ValueInt128.i128);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -267,7 +267,7 @@ int main() {
     try {
         my_fam->fam_compare_swap(item, 0, oldValueInt128.i128,
                                  newValueInt128.i128);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -275,7 +275,7 @@ int main() {
 
     try {
         ValueInt128.i128 = my_fam->fam_fetch_int128(item, 0);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_compare_swap_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_compare_swap_atomics_test.cpp
@@ -65,11 +65,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -87,11 +87,7 @@ int main() {
     int32_t valueInt32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -99,11 +95,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -114,11 +106,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 0, oldValueInt32, newValueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -126,11 +114,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_int32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -141,11 +125,7 @@ int main() {
     int64_t valueInt64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -153,11 +133,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -168,11 +144,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 0, oldValueInt64, newValueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -180,11 +152,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_int64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -195,11 +163,7 @@ int main() {
     uint32_t valueUint32 = 0xBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -207,11 +171,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -222,11 +182,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 0, oldValueUint32, newValueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -234,11 +190,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -249,11 +201,7 @@ int main() {
     uint64_t valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -261,11 +209,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -276,11 +220,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 0, oldValueUint64, newValueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -288,11 +228,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -303,11 +239,7 @@ int main() {
     valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -315,11 +247,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -330,11 +258,7 @@ int main() {
 
     try {
         my_fam->fam_compare_swap(item, 0, oldValueUint64, newValueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -342,11 +266,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -372,14 +292,14 @@ int main() {
 
     try {
         my_fam->fam_set(item, 0, valueInt128.i64[0]);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
     }
     try {
         my_fam->fam_set(item, sizeof(uint64_t), valueInt128.i64[1]);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -398,7 +318,7 @@ int main() {
     try {
         retValueInt128.i128 = my_fam->fam_compare_swap(
             item, 0, oldValueInt128.i128, newValueInt128.i128);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -423,7 +343,7 @@ int main() {
 
     try {
         my_fam->fam_get_blocking(&valueInt128, item, 0, sizeof(int128_t));
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -451,8 +371,7 @@ int main() {
 
     try {
         my_fam->fam_set(item, 0, valueInt128.i128);
-    }
-    catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -460,12 +379,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    }
-    catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -473,8 +387,7 @@ int main() {
 
     try {
         newValueInt128.i128 = my_fam->fam_fetch_int128(item, 0);
-    }
-    catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -482,12 +395,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    }
-    catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_copy_test.cpp
+++ b/test/unit-test/fam-api/fam_copy_test.cpp
@@ -54,11 +54,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     srcDesc = my_fam->fam_create_region("srcRegion", 8192, 0777, RAID1);
@@ -90,23 +90,12 @@ int main() {
         }
     }
 
-    int ret = 0;
-
     char *local = strdup("Test message");
 
     cout << "Content of source dataitem : " << local << endl;
     try {
-        ret = my_fam->fam_put_blocking(local, srcItem, 0, 13);
-        if (ret < 0) {
-            cout << "fam_put failed" << endl;
-            exit(1);
-        }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-
-    } catch (Fam_Datapath_Exception &e) {
+        my_fam->fam_put_blocking(local, srcItem, 0, 13);
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -142,22 +131,14 @@ int main() {
     for (int i = 0; i < MESSAGE_SIZE; i++) {
         try {
 
-            ret = my_fam->fam_get_blocking(local2, destItem[i], 0, 13);
-            if (ret < 0) {
-                cout << "fam_get failed" << endl;
-            }
+            my_fam->fam_get_blocking(local2, destItem[i], 0, 13);
 
             if (strncmp(local, local2, i + 1) == 0) {
                 cout << "Copy " << i << " : " << local2 << " : CORRECT" << endl;
             } else {
                 cout << "Copy " << i << " : " << local2 << " : WRONG" << endl;
             }
-        } catch (Fam_Permission_Exception &e) {
-            cout << "Exception caught" << endl;
-            cout << "Error msg: " << e.fam_error_msg() << endl;
-            cout << "Error: " << e.fam_error() << endl;
-
-        } catch (Fam_Datapath_Exception &e) {
+        } catch (Fam_Exception &e) {
             cout << "Exception caught" << endl;
             cout << "Error msg: " << e.fam_error_msg() << endl;
             cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_create_alloc_destroy_mt.cpp
+++ b/test/unit-test/fam-api/fam_create_alloc_destroy_mt.cpp
@@ -56,11 +56,11 @@ void *thr_func1(void *arg) {
     fam_opts.allocator = strdup("SHM");
     fam_opts.runtime = strdup("NONE");
 
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc1 = my_fam->fam_lookup_region("test111");
@@ -121,11 +121,11 @@ int main() {
     fam_opts.allocator = strdup("SHM");
     fam_opts.runtime = strdup("NONE");
 
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc1 = my_fam->fam_create_region("test111", 8192, 0777, RAID1);

--- a/test/unit-test/fam-api/fam_create_destroy_region_test.cpp
+++ b/test/unit-test/fam-api/fam_create_destroy_region_test.cpp
@@ -52,11 +52,11 @@ int main() {
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
     fam_opts.runtime = strdup("NONE");
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     int i = 0;

--- a/test/unit-test/fam-api/fam_create_destroy_region_test_mt.cpp
+++ b/test/unit-test/fam-api/fam_create_destroy_region_test_mt.cpp
@@ -116,11 +116,11 @@ int main() {
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
     fam_opts.runtime = strdup("NONE");
 
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     for (i = 0; i < 10; ++i) {

--- a/test/unit-test/fam-api/fam_fence_test.cpp
+++ b/test/unit-test/fam-api/fam_fence_test.cpp
@@ -50,11 +50,11 @@ int main() {
 
     fam_opts.memoryServer = strdup(TEST_MEMORY_SERVER);
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful." << endl;
     }
 
     Fam_Region_Descriptor *desc;

--- a/test/unit-test/fam-api/fam_fetch_arithmatic_atomics_nvmm_test.cpp
+++ b/test/unit-test/fam-api/fam_fetch_arithmatic_atomics_nvmm_test.cpp
@@ -63,11 +63,11 @@ int main() {
 
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
 
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -86,7 +86,7 @@ int main() {
     int32_t valueInt32 = 0xAAAA;
     try {
         my_fam->fam_set(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -95,7 +95,7 @@ int main() {
     valueInt32 = 0x1;
     try {
         valueInt32 = my_fam->fam_fetch_add(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -104,7 +104,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_int32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -114,7 +114,7 @@ int main() {
     valueInt32 = 0x1;
     try {
         valueInt32 = my_fam->fam_fetch_subtract(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -123,7 +123,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_int32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -134,7 +134,7 @@ int main() {
     int64_t valueInt64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -143,7 +143,7 @@ int main() {
     valueInt64 = 0x1;
     try {
         valueInt64 = my_fam->fam_fetch_add(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -152,7 +152,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_int64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -162,7 +162,7 @@ int main() {
     valueInt64 = 0x1;
     try {
         valueInt64 = my_fam->fam_fetch_subtract(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -171,7 +171,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_int64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_fetch_arithmatic_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_fetch_arithmatic_atomics_test.cpp
@@ -65,11 +65,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -88,11 +88,7 @@ int main() {
 
     try {
         my_fam->fam_set(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -100,11 +96,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -113,11 +105,7 @@ int main() {
     valueInt32 = 0x1;
     try {
         valueInt32 = my_fam->fam_fetch_add(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -126,11 +114,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_int32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -140,11 +124,7 @@ int main() {
     valueInt32 = 0x1;
     try {
         valueInt32 = my_fam->fam_fetch_subtract(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -153,11 +133,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_int32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -168,11 +144,7 @@ int main() {
     int64_t valueInt64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -180,11 +152,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -193,11 +161,7 @@ int main() {
     valueInt64 = 0x1;
     try {
         valueInt64 = my_fam->fam_fetch_add(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -206,11 +170,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_int64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -220,11 +180,7 @@ int main() {
     valueInt64 = 0x1;
     try {
         valueInt64 = my_fam->fam_fetch_subtract(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -233,11 +189,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_int64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -248,11 +200,7 @@ int main() {
     uint32_t valueUint32 = 0xBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -260,11 +208,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -273,11 +217,7 @@ int main() {
     valueUint32 = 0x1;
     try {
         valueUint32 = my_fam->fam_fetch_add(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -286,11 +226,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -300,11 +236,7 @@ int main() {
     valueUint32 = 0;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -312,11 +244,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -325,11 +253,7 @@ int main() {
     valueUint32 = 0x1;
     try {
         valueUint32 = my_fam->fam_fetch_subtract(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -338,11 +262,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -352,11 +272,7 @@ int main() {
     uint64_t valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -364,11 +280,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -377,11 +289,7 @@ int main() {
     valueUint64 = 0x1;
     try {
         valueUint64 = my_fam->fam_fetch_add(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -390,11 +298,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -404,11 +308,7 @@ int main() {
     valueUint64 = 0;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -416,11 +316,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -429,11 +325,7 @@ int main() {
     valueUint64 = 0x1;
     try {
         valueUint64 = my_fam->fam_fetch_subtract(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -442,11 +334,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -457,11 +345,7 @@ int main() {
     float valueFloat = 4.3f;
     try {
         my_fam->fam_set(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -469,11 +353,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -482,11 +362,7 @@ int main() {
     valueFloat = 1.2f;
     try {
         valueFloat = my_fam->fam_fetch_add(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -495,11 +371,7 @@ int main() {
 
     try {
         valueFloat = my_fam->fam_fetch_float(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -509,11 +381,7 @@ int main() {
     valueFloat = 1.2f;
     try {
         valueFloat = my_fam->fam_fetch_subtract(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -522,11 +390,7 @@ int main() {
 
     try {
         valueFloat = my_fam->fam_fetch_float(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -537,11 +401,7 @@ int main() {
     double valueDouble = 4.4e+38;
     try {
         my_fam->fam_set(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -549,11 +409,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -562,11 +418,7 @@ int main() {
     valueDouble = 1.2e+38;
     try {
         valueDouble = my_fam->fam_fetch_add(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -575,11 +427,7 @@ int main() {
 
     try {
         valueDouble = my_fam->fam_fetch_double(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -589,11 +437,7 @@ int main() {
     valueDouble = 1.2e+38;
     try {
         valueDouble = my_fam->fam_fetch_subtract(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -602,11 +446,7 @@ int main() {
 
     try {
         valueDouble = my_fam->fam_fetch_double(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_fetch_logical_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_fetch_logical_atomics_test.cpp
@@ -65,11 +65,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -87,11 +87,7 @@ int main() {
     uint32_t valueUint32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -99,11 +95,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -112,11 +104,7 @@ int main() {
     valueUint32 = 0x12345678;
     try {
         valueUint32 = my_fam->fam_fetch_and(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -126,11 +114,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -140,11 +124,7 @@ int main() {
     valueUint32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -152,11 +132,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -165,11 +141,7 @@ int main() {
     valueUint32 = 0x12345678;
     try {
         valueUint32 = my_fam->fam_fetch_or(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -179,11 +151,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -193,11 +161,7 @@ int main() {
     valueUint32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -205,11 +169,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -218,11 +178,7 @@ int main() {
     valueUint32 = 0x12345678;
     try {
         valueUint32 = my_fam->fam_fetch_xor(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -232,11 +188,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -247,11 +199,7 @@ int main() {
     uint64_t valueUint64 = 0xAAAAAAAAAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -259,11 +207,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -272,11 +216,7 @@ int main() {
     valueUint64 = 0x1234567890ABCDEF;
     try {
         valueUint64 = my_fam->fam_fetch_and(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -286,11 +226,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -300,11 +236,7 @@ int main() {
     valueUint64 = 0xAAAAAAAAAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -312,11 +244,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -325,11 +253,7 @@ int main() {
     valueUint64 = 0x1234567890ABCDEF;
     try {
         valueUint64 = my_fam->fam_fetch_or(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -339,11 +263,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -353,11 +273,7 @@ int main() {
     valueUint64 = 0xAAAAAAAAAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -365,11 +281,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -378,11 +290,7 @@ int main() {
     valueUint64 = 0x1234567890ABCDEF;
     try {
         valueUint64 = my_fam->fam_fetch_xor(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -391,11 +299,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_fetch_min_max_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_fetch_min_max_atomics_test.cpp
@@ -65,11 +65,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -88,11 +88,7 @@ int main() {
     int32_t valueInt32 = 0xBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -100,11 +96,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -113,11 +105,7 @@ int main() {
     valueInt32 = 0xAAAAAAAA;
     try {
         valueInt32 = my_fam->fam_fetch_min(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -126,11 +114,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -140,11 +124,7 @@ int main() {
     valueInt32 = 0xCCCCCCCC;
     try {
         valueInt32 = my_fam->fam_fetch_max(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -153,11 +133,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -168,11 +144,7 @@ int main() {
     int64_t valueInt64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -180,11 +152,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -193,11 +161,7 @@ int main() {
     valueInt64 = 0xAAAAAAAAAAAAAAAA;
     try {
         valueInt64 = my_fam->fam_fetch_min(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -206,11 +170,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -220,11 +180,7 @@ int main() {
     valueInt64 = 0xCCCCCCCCCCCCCCCC;
     try {
         valueInt64 = my_fam->fam_fetch_max(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -233,11 +189,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -248,11 +200,7 @@ int main() {
     uint32_t valueUint32 = 0xBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -260,11 +208,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -273,11 +217,7 @@ int main() {
     valueUint32 = 0x11111111;
     try {
         valueUint32 = my_fam->fam_fetch_min(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -286,11 +226,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -300,11 +236,7 @@ int main() {
     valueUint32 = 0xCCCCCCCC;
     try {
         valueUint32 = my_fam->fam_fetch_max(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -313,11 +245,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -328,11 +256,7 @@ int main() {
     uint64_t valueUint64 = 0xAAAAAAAAAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -340,11 +264,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -353,11 +273,7 @@ int main() {
     valueUint64 = 0x1111111111111111;
     try {
         valueUint64 = my_fam->fam_fetch_min(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -366,11 +282,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -380,11 +292,7 @@ int main() {
     valueUint64 = 0xCCCCCCCCCCCCCCCC;
     try {
         valueUint64 = my_fam->fam_fetch_max(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -393,11 +301,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -408,11 +312,7 @@ int main() {
     float valueFloat = 3.3f;
     try {
         my_fam->fam_set(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -420,11 +320,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -433,11 +329,7 @@ int main() {
     valueFloat = 1.2f;
     try {
         valueFloat = my_fam->fam_fetch_min(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -446,11 +338,7 @@ int main() {
 
     try {
         valueFloat = my_fam->fam_fetch_float(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -460,11 +348,7 @@ int main() {
     valueFloat = 5.6f;
     try {
         valueFloat = my_fam->fam_fetch_max(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -473,11 +357,7 @@ int main() {
 
     try {
         valueFloat = my_fam->fam_fetch_float(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -488,11 +368,7 @@ int main() {
     double valueDouble = 3.3e+38;
     try {
         my_fam->fam_set(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -500,11 +376,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -513,11 +385,7 @@ int main() {
     valueDouble = 1.2e+38;
     try {
         valueDouble = my_fam->fam_fetch_min(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -526,11 +394,7 @@ int main() {
 
     try {
         valueDouble = my_fam->fam_fetch_double(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -540,11 +404,7 @@ int main() {
     valueDouble = 5.6e+38;
     try {
         valueDouble = my_fam->fam_fetch_max(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -553,11 +413,7 @@ int main() {
 
     try {
         valueDouble = my_fam->fam_fetch_double(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_initialize_test.cpp
+++ b/test/unit-test/fam-api/fam_initialize_test.cpp
@@ -55,7 +55,7 @@ int main() {
         cout << "fam initialization successful" << endl;
         my_fam->fam_finalize("default");
         cout << "fam finalize successful" << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed:" << e.fam_error_msg() << endl;
     }
 }

--- a/test/unit-test/fam-api/fam_invalid_key_test.cpp
+++ b/test/unit-test/fam-api/fam_invalid_key_test.cpp
@@ -81,11 +81,11 @@ int main() {
     // Initialize openFAM API
     fam_opts.memoryServer = strdup("0:127.0.0.1");
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     // Create Region
@@ -122,12 +122,7 @@ int main() {
             cout << "fabric write failed" << endl;
             exit(1);
         }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-        fail++;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -143,12 +138,7 @@ int main() {
             cout << "fabric read failed" << endl;
             exit(1);
         }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-        fail++;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -177,7 +167,7 @@ int main() {
             cout << "fabric write failed" << endl;
             exit(1);
         }
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -195,7 +185,7 @@ int main() {
             cout << "fabric read failed" << endl;
             exit(1);
         }
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_nonfetch_arithmatic_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_nonfetch_arithmatic_atomics_test.cpp
@@ -93,11 +93,7 @@ int main() {
     int32_t valueInt32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -105,11 +101,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -118,11 +110,7 @@ int main() {
     valueInt32 = 0x1;
     try {
         my_fam->fam_add(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -130,11 +118,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -142,11 +126,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_int32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -156,11 +136,7 @@ int main() {
     valueInt32 = 0x1;
     try {
         my_fam->fam_subtract(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -168,11 +144,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -180,11 +152,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_int32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -195,11 +163,7 @@ int main() {
     int64_t valueInt64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -207,11 +171,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -220,11 +180,7 @@ int main() {
     valueInt64 = 0x1;
     try {
         my_fam->fam_add(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -232,11 +188,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -244,11 +196,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_int64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -258,11 +206,7 @@ int main() {
     valueInt64 = 0x1;
     try {
         my_fam->fam_subtract(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -270,11 +214,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -282,11 +222,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_int64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -297,11 +233,7 @@ int main() {
     uint32_t valueUint32 = 0xBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -309,11 +241,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -322,11 +250,7 @@ int main() {
     valueUint32 = 0x1;
     try {
         my_fam->fam_add(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -334,11 +258,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -346,11 +266,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -360,11 +276,7 @@ int main() {
     valueUint32 = 0;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -372,11 +284,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -385,11 +293,7 @@ int main() {
     valueUint32 = 0x1;
     try {
         my_fam->fam_subtract(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -397,11 +301,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -409,11 +309,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -424,11 +320,7 @@ int main() {
     uint64_t valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -436,11 +328,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -449,11 +337,7 @@ int main() {
     valueUint64 = 0x1;
     try {
         my_fam->fam_add(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -461,11 +345,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -473,11 +353,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -487,11 +363,7 @@ int main() {
     valueUint64 = 0;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -499,11 +371,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -512,11 +380,7 @@ int main() {
     valueUint64 = 0x1;
     try {
         my_fam->fam_subtract(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -524,11 +388,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -536,11 +396,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -551,11 +407,7 @@ int main() {
     float valueFloat = 4.3f;
     try {
         my_fam->fam_set(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -563,11 +415,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -576,11 +424,7 @@ int main() {
     valueFloat = 1.2f;
     try {
         my_fam->fam_add(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -588,11 +432,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -600,11 +440,7 @@ int main() {
 
     try {
         valueFloat = my_fam->fam_fetch_float(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -614,11 +450,7 @@ int main() {
     valueFloat = 1.2f;
     try {
         my_fam->fam_subtract(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -626,11 +458,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -638,11 +466,7 @@ int main() {
 
     try {
         valueFloat = my_fam->fam_fetch_float(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -653,11 +477,7 @@ int main() {
     double valueDouble = 4.4e+38;
     try {
         my_fam->fam_set(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -665,11 +485,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -678,11 +494,7 @@ int main() {
     valueDouble = 1.2e+38;
     try {
         my_fam->fam_add(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -690,11 +502,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -702,11 +510,7 @@ int main() {
 
     try {
         valueDouble = my_fam->fam_fetch_double(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -716,11 +520,7 @@ int main() {
     valueDouble = 1.2e+38;
     try {
         my_fam->fam_subtract(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -728,11 +528,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -740,11 +536,7 @@ int main() {
 
     try {
         valueDouble = my_fam->fam_fetch_double(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_nonfetch_logical_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_nonfetch_logical_atomics_test.cpp
@@ -65,11 +65,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -87,11 +87,7 @@ int main() {
     uint32_t valueUint32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -99,11 +95,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -112,11 +104,7 @@ int main() {
     valueUint32 = 0x12345678;
     try {
         my_fam->fam_and(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -124,11 +112,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -136,11 +120,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -150,11 +130,7 @@ int main() {
     valueUint32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -162,11 +138,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -175,11 +147,7 @@ int main() {
     valueUint32 = 0x12345678;
     try {
         my_fam->fam_or(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -187,11 +155,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -199,11 +163,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -213,11 +173,7 @@ int main() {
     valueUint32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -225,11 +181,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -238,11 +190,7 @@ int main() {
     valueUint32 = 0x12345678;
     try {
         my_fam->fam_xor(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -250,11 +198,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -262,11 +206,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -277,11 +217,7 @@ int main() {
     uint64_t valueUint64 = 0xAAAAAAAAAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -289,11 +225,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -302,11 +234,7 @@ int main() {
     valueUint64 = 0x1234567890ABCDEF;
     try {
         my_fam->fam_and(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -314,11 +242,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -326,11 +250,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -340,11 +260,7 @@ int main() {
     valueUint64 = 0xAAAAAAAAAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -352,11 +268,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -365,11 +277,7 @@ int main() {
     valueUint64 = 0x1234567890ABCDEF;
     try {
         my_fam->fam_or(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -377,11 +285,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -389,11 +293,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -403,11 +303,7 @@ int main() {
     valueUint64 = 0xAAAAAAAAAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -415,11 +311,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -428,11 +320,7 @@ int main() {
     valueUint64 = 0x1234567890ABCDEF;
     try {
         my_fam->fam_xor(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -440,11 +328,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -452,11 +336,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_nonfetch_min_max_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_nonfetch_min_max_atomics_test.cpp
@@ -65,11 +65,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -88,11 +88,7 @@ int main() {
     int32_t valueInt32 = 0xBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -100,11 +96,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -113,11 +105,7 @@ int main() {
     valueInt32 = 0xAAAAAAAA;
     try {
         my_fam->fam_min(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -125,11 +113,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -137,11 +121,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -151,11 +131,7 @@ int main() {
     valueInt32 = 0xCCCCCCCC;
     try {
         my_fam->fam_max(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -163,11 +139,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -175,11 +147,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -190,11 +158,7 @@ int main() {
     int64_t valueInt64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -202,11 +166,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -215,11 +175,7 @@ int main() {
     valueInt64 = 0xAAAAAAAAAAAAAAAA;
     try {
         my_fam->fam_min(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -227,11 +183,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -239,11 +191,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -253,11 +201,7 @@ int main() {
     valueInt64 = 0xCCCCCCCCCCCCCCCC;
     try {
         my_fam->fam_max(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -265,11 +209,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -277,11 +217,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -292,11 +228,7 @@ int main() {
     uint32_t valueUint32 = 0xBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -304,11 +236,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -317,11 +245,7 @@ int main() {
     valueUint32 = 0x11111111;
     try {
         my_fam->fam_min(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -329,11 +253,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -341,11 +261,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -355,11 +271,7 @@ int main() {
     valueUint32 = 0xCCCCCCCC;
     try {
         my_fam->fam_max(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -367,11 +279,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -379,11 +287,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -394,11 +298,7 @@ int main() {
     uint64_t valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -406,11 +306,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -419,11 +315,7 @@ int main() {
     valueUint64 = 0xAAAAAAAAAAAAAAAA;
     try {
         my_fam->fam_min(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -431,11 +323,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -443,11 +331,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -457,11 +341,7 @@ int main() {
     valueUint64 = 0xCCCCCCCCCCCCCCCC;
     try {
         my_fam->fam_max(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -469,11 +349,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -481,11 +357,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -496,11 +368,7 @@ int main() {
     float valueFloat = 3.3f;
     try {
         my_fam->fam_set(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -508,11 +376,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -521,11 +385,7 @@ int main() {
     valueFloat = 1.2f;
     try {
         my_fam->fam_min(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -533,11 +393,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -545,11 +401,7 @@ int main() {
 
     try {
         valueFloat = my_fam->fam_fetch_float(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -559,11 +411,7 @@ int main() {
     valueFloat = 5.6f;
     try {
         my_fam->fam_max(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -571,11 +419,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -583,11 +427,7 @@ int main() {
 
     try {
         valueFloat = my_fam->fam_fetch_float(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -598,11 +438,7 @@ int main() {
     double valueDouble = 3.3e+38;
     try {
         my_fam->fam_set(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -610,11 +446,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -623,11 +455,7 @@ int main() {
     valueDouble = 1.2e+38;
     try {
         my_fam->fam_min(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -635,11 +463,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -647,11 +471,7 @@ int main() {
 
     try {
         valueDouble = my_fam->fam_fetch_double(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -661,11 +481,7 @@ int main() {
     valueDouble = 5.6e+38;
     try {
         my_fam->fam_max(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -673,11 +489,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -685,11 +497,7 @@ int main() {
 
     try {
         valueDouble = my_fam->fam_fetch_double(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_noperm_test.cpp
+++ b/test/unit-test/fam-api/fam_noperm_test.cpp
@@ -52,11 +52,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test1", 8192, 0777, RAID1);
@@ -74,12 +74,7 @@ int main() {
     try {
         // write should fail as we have read-only perm
         my_fam->fam_put_blocking(local, item, 0, 13);
-    } catch (Fam_Permission_Exception &e) {
-        pass++;
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam_put_blocking failed as expected with no permission"
              << endl;
         pass++;

--- a/test/unit-test/fam-api/fam_options_test.cpp
+++ b/test/unit-test/fam-api/fam_options_test.cpp
@@ -57,10 +57,10 @@ int main() {
         // Throws grpc exception because of wrong grpc port.
         // Continue the test, as this is only to test fam_options.
         my_fam->fam_initialize("default", &fam_opts);
-    } catch (Fam_Allocator_Exception &e) {
-        cout << "fam initialization failed with Fam_Allocator_Exception. "
-                "continue to test fam_list_options."
-             << endl;
+    } catch (Fam_Exception &e) {
+        cout << "fam initialization failed with fam_error:" << e.fam_error()
+             << ":" << e.fam_error_msg()
+             << ", continue to test fam_list_options." << endl;
     }
 
     optList = my_fam->fam_list_options();
@@ -93,7 +93,7 @@ int main() {
         char *badOpt = strdup("badOption");
         char *optValue = (char *)my_fam->fam_get_option(badOpt);
         cout << optList[i] << ":" << optValue << endl;
-    } catch (Fam_InvalidOption_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_put_get.cpp
+++ b/test/unit-test/fam-api/fam_put_get.cpp
@@ -52,11 +52,11 @@ int main() {
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
 
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -70,7 +70,6 @@ int main() {
         cout << "fam allocation of data item 'first' failed" << endl;
         exit(1);
     }
-    int ret = 0;
     Fam_Stat *info = (Fam_Stat *)malloc(sizeof(Fam_Stat));
     my_fam->fam_stat(desc, info);
 
@@ -85,17 +84,8 @@ int main() {
     free(info);
     char *local = strdup("Test message");
     try {
-        ret = my_fam->fam_put_blocking(local, item, 0, 13);
-        if (ret < 0) {
-            cout << "fam_put failed" << endl;
-            exit(1);
-        }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-
-    } catch (Fam_Datapath_Exception &e) {
+        my_fam->fam_put_blocking(local, item, 0, 13);
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -104,16 +94,8 @@ int main() {
     char *local2 = (char *)malloc(20);
     try {
 
-        ret = my_fam->fam_get_blocking(local2, item, 0, 13);
-        if (ret < 0) {
-            cout << "fam_get failed" << endl;
-        }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-
-    } catch (Fam_Datapath_Exception &e) {
+        my_fam->fam_get_blocking(local2, item, 0, 13);
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_put_get_multiple.cpp
+++ b/test/unit-test/fam-api/fam_put_get_multiple.cpp
@@ -53,11 +53,11 @@ int main() {
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
     fam_opts.famThreadModel = strdup("FAM_THREAD_MULTIPLE");
 
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -71,21 +71,11 @@ int main() {
         cout << "fam allocation of data item 'first' failed" << endl;
         exit(1);
     }
-    int ret = 0;
 
     char *local = strdup("Test message");
     try {
-        ret = my_fam->fam_put_blocking(local, item, 0, 13);
-        if (ret < 0) {
-            cout << "fam_put failed" << endl;
-            exit(1);
-        }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-
-    } catch (Fam_Datapath_Exception &e) {
+        my_fam->fam_put_blocking(local, item, 0, 13);
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -93,17 +83,8 @@ int main() {
     // allocate local memory to receive 20 elements
     char *local2 = (char *)malloc(20);
     try {
-
-        ret = my_fam->fam_get_blocking(local2, item, 0, 13);
-        if (ret < 0) {
-            cout << "fam_get failed" << endl;
-        }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-
-    } catch (Fam_Datapath_Exception &e) {
+        my_fam->fam_get_blocking(local2, item, 0, 13);
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_put_get_region_ctx.cpp
+++ b/test/unit-test/fam-api/fam_put_get_region_ctx.cpp
@@ -78,21 +78,10 @@ int main() {
         cout << "Error: " << e.fam_error() << endl;
     }
 
-    int ret = 0;
-
     char *local = strdup("Test message");
     try {
-        ret = my_fam->fam_put_blocking(local, item, 0, 13);
-        if (ret < 0) {
-            cout << "fam_put failed" << endl;
-            exit(1);
-        }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-
-    } catch (Fam_Datapath_Exception &e) {
+        my_fam->fam_put_blocking(local, item, 0, 13);
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -100,17 +89,8 @@ int main() {
     // allocate local memory to receive 20 elements
     char *local2 = (char *)malloc(20);
     try {
-
-        ret = my_fam->fam_get_blocking(local2, item, 0, 13);
-        if (ret < 0) {
-            cout << "fam_get failed" << endl;
-        }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-
-    } catch (Fam_Datapath_Exception &e) {
+        my_fam->fam_get_blocking(local2, item, 0, 13);
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_put_get_user_desc.cpp
+++ b/test/unit-test/fam-api/fam_put_get_user_desc.cpp
@@ -52,11 +52,11 @@ int main() {
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
 
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -70,7 +70,6 @@ int main() {
         cout << "fam allocation of data item 'first' failed" << endl;
         exit(1);
     }
-    int ret = 0;
     Fam_Stat *info = (Fam_Stat *)malloc(sizeof(Fam_Stat));
     my_fam->fam_stat(desc, info);
     uint64_t regionSize = info->size;
@@ -88,17 +87,8 @@ int main() {
 
     char *local = strdup("Test message");
     try {
-        ret = my_fam->fam_put_blocking(local, itemCopy, 0, 13);
-        if (ret < 0) {
-            cout << "fam_put failed" << endl;
-            exit(1);
-        }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-
-    } catch (Fam_Datapath_Exception &e) {
+        my_fam->fam_put_blocking(local, itemCopy, 0, 13);
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -106,17 +96,8 @@ int main() {
     // allocate local memory to receive 20 elements
     char *local2 = (char *)malloc(20);
     try {
-
-        ret = my_fam->fam_get_blocking(local2, itemCopy, 0, 13);
-        if (ret < 0) {
-            cout << "fam_get failed" << endl;
-        }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-
-    } catch (Fam_Datapath_Exception &e) {
+        my_fam->fam_get_blocking(local2, itemCopy, 0, 13);
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_quiet_put_get_nonblocking.cpp
+++ b/test/unit-test/fam-api/fam_quiet_put_get_nonblocking.cpp
@@ -51,11 +51,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -74,11 +74,7 @@ int main() {
     char *local = strdup("Test message");
     try {
         my_fam->fam_put_nonblocking(local, item, 0, 13);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -86,11 +82,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -104,22 +96,14 @@ int main() {
         if (ret < 0) {
             cout << "fam_get failed" << endl;
         }
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
     }
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/fam-api/fam_scatter_gather_index_blocking.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_index_blocking.cpp
@@ -53,11 +53,11 @@ int main() {
     fam_opts.memoryServer = strdup(TEST_MEMORY_SERVER);
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful." << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);

--- a/test/unit-test/fam-api/fam_scatter_gather_index_nonblocking.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_index_nonblocking.cpp
@@ -54,11 +54,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful." << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -91,10 +91,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Timeout_Exception &e) {
-        cout << "fam quiet failed:" << e.fam_error_msg() << endl;
-        exit(1);
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam quiet failed:" << e.fam_error_msg() << endl;
         exit(1);
     }
@@ -105,10 +102,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Timeout_Exception &e) {
-        cout << "fam quiet failed:" << e.fam_error_msg() << endl;
-        exit(1);
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam quiet failed:" << e.fam_error_msg() << endl;
         exit(1);
     }

--- a/test/unit-test/fam-api/fam_scatter_gather_index_user_desc.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_index_user_desc.cpp
@@ -54,11 +54,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
     fam_opts.runtime = strdup("NONE");
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful." << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_blocking.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_blocking.cpp
@@ -53,11 +53,11 @@ int main() {
     fam_opts.memoryServer = strdup(TEST_MEMORY_SERVER);
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful." << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_blocking_with_validation.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_blocking_with_validation.cpp
@@ -56,11 +56,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful." << endl;
     }
 
     desc = my_fam->fam_create_region("sg_test", 1048576, 0777, RAID1);

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_nonblocking.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_nonblocking.cpp
@@ -54,11 +54,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful." << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -91,10 +91,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Timeout_Exception &e) {
-        cout << "fam quiet failed:" << e.fam_error_msg() << endl;
-        exit(1);
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam quiet failed:" << e.fam_error_msg() << endl;
         exit(1);
     }
@@ -105,10 +102,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Timeout_Exception &e) {
-        cout << "fam quiet failed:" << e.fam_error_msg() << endl;
-        exit(1);
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam quiet failed:" << e.fam_error_msg() << endl;
         exit(1);
     }

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_nonblocking_with_validation.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_nonblocking_with_validation.cpp
@@ -56,11 +56,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful." << endl;
     }
 
     desc = my_fam->fam_create_region("sg_test", 1048576, 0777, RAID1);
@@ -107,10 +107,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Timeout_Exception &e) {
-        cout << "fam quiet failed:" << e.fam_error_msg() << endl;
-        exit(1);
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam quiet failed:" << e.fam_error_msg() << endl;
         exit(1);
     }
@@ -125,10 +122,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Timeout_Exception &e) {
-        cout << "fam quiet failed:" << e.fam_error_msg() << endl;
-        exit(1);
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam quiet failed:" << e.fam_error_msg() << endl;
         exit(1);
     }
@@ -151,10 +145,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Timeout_Exception &e) {
-        cout << "fam quiet failed:" << e.fam_error_msg() << endl;
-        exit(1);
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam quiet failed:" << e.fam_error_msg() << endl;
         exit(1);
     }

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_user_desc.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_user_desc.cpp
@@ -53,11 +53,11 @@ int main() {
     fam_opts.memoryServer = strdup(TEST_MEMORY_SERVER);
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful." << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);

--- a/test/unit-test/fam-api/fam_swap_test.cpp
+++ b/test/unit-test/fam-api/fam_swap_test.cpp
@@ -65,11 +65,11 @@ int main() {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.libfabricPort = strdup(TEST_LIBFABRIC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
@@ -88,11 +88,7 @@ int main() {
     int32_t valueInt32 = 0xAAAAAAAA;
     try {
         my_fam->fam_set(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -100,11 +96,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -113,11 +105,7 @@ int main() {
     valueInt32 = 0x11111111;
     try {
         my_fam->fam_swap(item, 0, valueInt32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -125,11 +113,7 @@ int main() {
 
     try {
         valueInt32 = my_fam->fam_fetch_int32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -140,11 +124,7 @@ int main() {
     int64_t valueInt64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -152,11 +132,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -165,11 +141,7 @@ int main() {
     valueInt64 = 0x1111111111111111;
     try {
         my_fam->fam_swap(item, 0, valueInt64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -177,11 +149,7 @@ int main() {
 
     try {
         valueInt64 = my_fam->fam_fetch_int64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -192,11 +160,7 @@ int main() {
     uint32_t valueUint32 = 0xBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -204,11 +168,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -217,11 +177,7 @@ int main() {
     valueUint32 = 0x11111111;
     try {
         my_fam->fam_swap(item, 0, valueUint32);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -229,11 +185,7 @@ int main() {
 
     try {
         valueUint32 = my_fam->fam_fetch_uint32(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -244,11 +196,7 @@ int main() {
     uint64_t valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
         my_fam->fam_set(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -256,11 +204,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -269,11 +213,7 @@ int main() {
     valueUint64 = 0x1111111111111111;
     try {
         my_fam->fam_swap(item, 0, valueUint64);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -281,11 +221,7 @@ int main() {
 
     try {
         valueUint64 = my_fam->fam_fetch_uint64(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -296,11 +232,7 @@ int main() {
     float valueFloat = 3.3f;
     try {
         my_fam->fam_set(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -308,11 +240,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -321,11 +249,7 @@ int main() {
     valueFloat = 10.5f;
     try {
         my_fam->fam_swap(item, 0, valueFloat);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -333,11 +257,7 @@ int main() {
 
     try {
         valueFloat = my_fam->fam_fetch_float(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -348,11 +268,7 @@ int main() {
     double valueDouble = 3.3e+38;
     try {
         my_fam->fam_set(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -360,11 +276,7 @@ int main() {
 
     try {
         my_fam->fam_quiet();
-    } catch (Fam_Datapath_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Timeout_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -373,11 +285,7 @@ int main() {
     valueDouble = 6.5e+38;
     try {
         my_fam->fam_swap(item, 0, valueDouble);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
@@ -385,11 +293,7 @@ int main() {
 
     try {
         valueDouble = my_fam->fam_fetch_double(item, 0);
-    } catch (Fam_Permission_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;

--- a/test/unit-test/metadata/fam_metadata_regress_test.cpp
+++ b/test/unit-test/metadata/fam_metadata_regress_test.cpp
@@ -153,7 +153,7 @@ TEST(FamMetadata, RegionFail) {
 
     EXPECT_THROW(
         my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1),
-        Fam_Allocator_Exception);
+        Fam_Exception);
 
     regionId = node.regionId;
 
@@ -186,7 +186,7 @@ TEST(FamMetadata, RegionFail) {
     EXPECT_EQ(META_KEY_DOES_NOT_EXIST,
               manager->metadata_delete_region(testRegion));
 
-    EXPECT_THROW(my_fam->fam_destroy_region(desc), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_destroy_region(desc), Fam_Exception);
 
     EXPECT_EQ(META_NO_ERROR,
               manager->metadata_insert_region(regionId, testRegion, regnode));
@@ -326,7 +326,7 @@ TEST(FamMetadata, DataitemFail) {
     EXPECT_NE((void *)NULL, item);
 
     EXPECT_THROW(my_fam->fam_allocate(firstItem, 1024, 0777, desc),
-                 Fam_Allocator_Exception);
+                 Fam_Exception);
 
     EXPECT_EQ(META_NO_ERROR,
               manager->metadata_find_dataitem(firstItem, regionId, dinode));
@@ -415,7 +415,7 @@ TEST(FamMetadata, DataitemFail) {
     EXPECT_EQ(META_NO_ERROR,
               manager->metadata_delete_dataitem(dataitemId, testRegion));
 
-    EXPECT_THROW(my_fam->fam_deallocate(item), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_deallocate(item), Fam_Exception);
 
     EXPECT_EQ(META_NO_ERROR, manager->metadata_insert_dataitem(
                                  dataitemId, regionId, datanode, firstItem));
@@ -424,7 +424,7 @@ TEST(FamMetadata, DataitemFail) {
 
     EXPECT_EQ(META_NO_ERROR, manager->metadata_delete_region(testRegion));
 
-    EXPECT_THROW(my_fam->fam_destroy_region(desc), Fam_Allocator_Exception);
+    EXPECT_THROW(my_fam->fam_destroy_region(desc), Fam_Exception);
 
     EXPECT_EQ(META_NO_ERROR,
               manager->metadata_insert_region(regionId, testRegion, regnode));

--- a/test/unit-test/metadata/fam_metadata_test.cpp
+++ b/test/unit-test/metadata/fam_metadata_test.cpp
@@ -36,6 +36,7 @@
 #include "common/fam_test_config.h"
 
 #include <fam/fam.h>
+#include <fam/fam_exception.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -61,11 +62,11 @@ int main(int argc, char *argv[]) {
     fam_opts.grpcPort = strdup(TEST_GRPC_PORT);
     fam_opts.allocator = strdup(TEST_ALLOCATOR);
     fam_opts.runtime = strdup("NONE");
-    if (my_fam->fam_initialize("default", &fam_opts) < 0) {
+    try {
+        my_fam->fam_initialize("default", &fam_opts);
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed" << endl;
         exit(1);
-    } else {
-        cout << "fam initialization successful" << endl;
     }
 
     Fam_Region_Descriptor *desc[2];

--- a/test/unit-test/pmix/fam_initialize_runtime_none.cpp
+++ b/test/unit-test/pmix/fam_initialize_runtime_none.cpp
@@ -55,7 +55,7 @@ int main() {
         my_fam->fam_initialize("default", &fam_opts);
         my_fam->fam_finalize("default");
 
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed:" << e.fam_error_msg() << endl;
     }
 }

--- a/test/unit-test/pmix/fam_initialize_runtime_pmi2.cpp
+++ b/test/unit-test/pmix/fam_initialize_runtime_pmi2.cpp
@@ -60,7 +60,7 @@ int main() {
         cout << "Node : " << *myPE << " number of nodes is " << *numPEs << endl;
         my_fam2->fam_finalize("default");
 
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed:" << e.fam_error_msg() << endl;
     }
 }

--- a/test/unit-test/pmix/fam_initialize_runtime_pmix.cpp
+++ b/test/unit-test/pmix/fam_initialize_runtime_pmix.cpp
@@ -64,7 +64,7 @@ int main() {
                 "--"
              << endl;
 
-    } catch (Fam_Datapath_Exception &e) {
+    } catch (Fam_Exception &e) {
         cout << "fam initialization failed:" << e.fam_error_msg() << endl;
     }
 }


### PR DESCRIPTION
This fix includes following changes:
- All APIs return Fam_Exception on failure
- Change in API specification where return value is not effectively used.
  Return value changed from int to void for fam_initialize, etc.
- Error message includes function name and line no., from where the exception
  is raised.