### PR TITLE
Disable background worker threads 

### DIFF
--- a/src/allocator/memserver_allocator.cpp
+++ b/src/allocator/memserver_allocator.cpp
@@ -167,7 +167,7 @@ int Memserver_Allocator::create_region(string name, uint64_t &regionId,
         throw Memserver_Exception(HEAP_NOT_FOUND, message.str().c_str());
     }
     NVMM_PROFILE_START_OPS()
-    ret = heap->Open();
+    ret = heap->Open(NVMM_NO_BG_THREAD);
     NVMM_PROFILE_END_OPS(Heap_Open)
     if (ret != NO_ERROR) {
         message << "Can not open heap";
@@ -456,7 +456,7 @@ int Memserver_Allocator::open_heap(uint64_t regionId) {
             throw Memserver_Exception(HEAP_NOT_OPENED, message.str().c_str());
         }
         NVMM_PROFILE_START_OPS()
-        heap->Open();
+        heap->Open(NVMM_NO_BG_THREAD);
         NVMM_PROFILE_END_OPS(Heap_Open)
         NVMM_PROFILE_START_OPS()
         pthread_mutex_lock(&heapMapLock);


### PR DESCRIPTION
Pass "NVMM_NO_BG_THREAD" flag to heap->Open. It disables NVMM background worker threads. Even though we disable it in OpenFAM, Background worker threads will be spawned by KVS radixtree. 

This change will not be complete until radixtree changes are done. 