### PR TITLE
Code Coverage Build fix with Profiling enabled

### DIFF
--- a/src/cis/fam_cis_direct.cpp
+++ b/src/cis/fam_cis_direct.cpp
@@ -1013,8 +1013,8 @@ uint64_t Fam_CIS_Direct::get_dataitem_id(uint64_t offset,
     return ((memoryServerId << 32) + offset / MIN_OBJ_SIZE);
 }
 size_t Fam_CIS_Direct::get_addr_size(uint64_t memoryServerId) {
-    CIS_DIRECT_PROFILE_START_OPS()
     size_t addrSize = 0;
+    CIS_DIRECT_PROFILE_START_OPS()
     Fam_Memory_Service *memoryService = get_memory_service(memoryServerId);
     addrSize = memoryService->get_addr_size();
     CIS_DIRECT_PROFILE_END_OPS(cis_get_addr_size);

--- a/test/apps/pagerank/fam_csr_preload_parmat.cpp
+++ b/test/apps/pagerank/fam_csr_preload_parmat.cpp
@@ -1,8 +1,9 @@
 /*
- * fam_csr_preload_parmat.cpp 
- * Copyright (c) 2019 Hewlett Packard Enterprise Development, LP. All rights
- * reserved. Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * fam_csr_preload_parmat.cpp
+ * Copyright (c) 2019-2020 Hewlett Packard Enterprise Development, LP. All
+ * rights reserved. Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
@@ -28,11 +29,12 @@
  *
  */
 #include "common/fam_options.h"
+#include "fam_utils.h"
 #include "pagerank_common.h"
 #include <fam/fam.h>
 #include <fam/fam_exception.h>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 //#include "common/fam_test_config.h"
 
 using namespace std;
@@ -98,6 +100,7 @@ int LoadGraphMatrix(std::istream& istream, size_t num_rows, size_t num_elements,
                
     return 0;
 }
+
 //
 // This file loads sorted parmat output into fam
 // @input : argv[1] - parmat file
@@ -129,10 +132,16 @@ int main(int argc, char **argv) {
     cout << "nnz : " << nnz << endl;
     cout << "Data Path : " << parmat_file << endl;
 
+    uint64_t start_time = fam_test_get_time();
+    cout << "Total elapse load Start time in nanoseconds = " << start_time
+         << endl;
     nelements = nnz * matRowCount;
 
     // FAM initialize and create region
-    region = spmv_fam_initialize(nelements * 3 * sizeof(int64_t) + 2 * matRowCount * sizeof(double));
+    // TODO: If region creation fails , consider changing the size of the region
+    region = spmv_fam_initialize(
+        (nelements * 3 * sizeof(int64_t) + 2 * matRowCount * sizeof(double)) *
+        4);
 
     // Set config
     config.nrows = matRowCount;
@@ -159,4 +168,7 @@ int main(int argc, char **argv) {
     delete region;
     my_fam->fam_finalize("default");
     delete my_fam;
+
+    uint64_t final_time = fam_test_get_time() - start_time;
+    cout << dec << "load time in nanoseconds = " << final_time << endl;
 }

--- a/test/apps/pagerank/fam_csr_preload_parmat.cpp
+++ b/test/apps/pagerank/fam_csr_preload_parmat.cpp
@@ -133,8 +133,6 @@ int main(int argc, char **argv) {
     cout << "Data Path : " << parmat_file << endl;
 
     uint64_t start_time = fam_test_get_time();
-    cout << "Total elapse load Start time in nanoseconds = " << start_time
-         << endl;
     nelements = nnz * matRowCount;
 
     // FAM initialize and create region

--- a/test/apps/pagerank/fam_pagerank_parmat.cpp
+++ b/test/apps/pagerank/fam_pagerank_parmat.cpp
@@ -326,7 +326,7 @@ int main(int argc, char **argv) {
         if (myPE == 0) {
             // For the next iteration read rows from the beginning
             spmv_set_row_zero(headerDataItem);
-            // fam_stream << "Completed !!!" << endl;
+            fam_stream << "Completed !!!" << endl;
         }
         my_fam->fam_barrier_all();
     }

--- a/test/apps/pagerank/fam_pagerank_parmat.cpp
+++ b/test/apps/pagerank/fam_pagerank_parmat.cpp
@@ -1,8 +1,9 @@
 /*
  * fam_pagerank_parmat.cpp
- * Copyright (c) 2019 Hewlett Packard Enterprise Development, LP. All rights
- * reserved. Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Copyright (c) 2019-2020 Hewlett Packard Enterprise Development, LP. All
+ * rights reserved. Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
@@ -29,11 +30,12 @@
  */
 #include "common/fam_options.h"
 #include "common/fam_test_config.h"
+#include "fam_utils.h"
 #include "pagerank_common.h"
 #include <fam/fam.h>
 #include <fam/fam_exception.h>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 using namespace std;
 using namespace openfam;
@@ -167,6 +169,8 @@ int main(int argc, char **argv) {
 		exit(-1);
 	}
     }
+    my_fam->fam_barrier_all();
+    uint64_t start_time = fam_test_get_time();
 
     for (int iter = 0; iter < pagerank_Iter; iter++) {
         // Read input vector, Vector0 or Vector1 based on iteration
@@ -181,9 +185,11 @@ int main(int argc, char **argv) {
         resultDataItem =
             spmv_get_dataitem(vector_dataitem_name[(iter + 1) % 2]);
 
+#ifdef TRACE
         if (myPE == 0)
             fam_stream << "Reading input  vector, pagerank iter = " << iter
                        << endl;
+#endif
 
         for (int i = 0; i < nsegments; i = i + 1) {
             // Each PE to read rows_per_iter rows
@@ -285,8 +291,8 @@ int main(int argc, char **argv) {
                     fam_stream << "Reading value data failed" << endl;
                     exit(1);
                 }
-		std::cout<<"Reading values successful!!"<<std::endl;
 #ifdef TRACE
+                std::cout << "Reading values successful!!" << std::endl;
                 std::cout << "#### Row : " << rowBegin << " : " << rowEnd
                           << " colptr : " << local_row[0] << " : "
                           << local_row[curRows] << std::endl;
@@ -320,10 +326,13 @@ int main(int argc, char **argv) {
         if (myPE == 0) {
             // For the next iteration read rows from the beginning
             spmv_set_row_zero(headerDataItem);
-            fam_stream << "Completed !!!" << endl;
+            // fam_stream << "Completed !!!" << endl;
         }
         my_fam->fam_barrier_all();
     }
+    uint64_t final_time = fam_test_get_time() - start_time;
+    cout << "Pagerank time for PE=" << myPE << " for no. of iteration "
+         << pagerank_Iter << " in nanoseconds = " << final_time << endl;
 #ifdef PRINT_OUTPUT
     if (myPE == 0) {
         ofstream outfile;
@@ -352,5 +361,6 @@ int main(int argc, char **argv) {
 
     my_fam->fam_finalize("default");
     delete my_fam;
+
     return 0;
 }

--- a/test/util/fam_utils.h
+++ b/test/util/fam_utils.h
@@ -1,6 +1,6 @@
 /*
  * fam_utils.h
- * Copyright (c) 2019-20 Hewlett Packard Enterprise Development, LP. All rights
+ * Copyright (c) 2019-2020 Hewlett Packard Enterprise Development, LP. All rights
  * reserved. Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  * 1. Redistributions of source code must retain the above copyright notice,

--- a/test/util/fam_utils.h
+++ b/test/util/fam_utils.h
@@ -1,6 +1,6 @@
 /*
  * fam_utils.h
- * Copyright (c) 2019 Hewlett Packard Enterprise Development, LP. All rights
+ * Copyright (c) 2019-20 Hewlett Packard Enterprise Development, LP. All rights
  * reserved. Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  * 1. Redistributions of source code must retain the above copyright notice,

--- a/test/util/fam_utils.h
+++ b/test/util/fam_utils.h
@@ -30,7 +30,11 @@
 #ifndef FAM_UTILS_H_
 #define FAM_UTILS_H_
 
+#include <chrono>
 #include <fam/fam.h>
+
+using namespace std;
+using namespace chrono;
 
 #define create_region(pass, my_fam, region, name, size, permission,            \
                       redundancy)                                              \
@@ -103,4 +107,13 @@
         cout << "Error msg: " << e.fam_error_msg() << endl;                    \
         cout << "Error: " << e.fam_error() << endl;                            \
     }
+
+static inline uint64_t fam_test_get_time() {
+    long int time = static_cast<long int>(
+        duration_cast<nanoseconds>(
+            high_resolution_clock::now().time_since_epoch())
+            .count());
+    return time;
+}
+
 #endif /* end of FAM_UTILS_H_ */


### PR DESCRIPTION
We are seeing following error while enabling code coverage with profiling flag like:

#cmake ../.. -DARG_OPENFAM_MODEL=shared_memory -DCMAKE_BUILD_TYPE=Coverage -DENABLE_FAM_PROFILING=1 -DENABLE_LIBFABRIC_PROFILING=1 -DENABLE_MEMORYSERVER_PROFILING=1

Error as:
/home/rajakr/development/OpenFAM/src/cis/fam_cis_direct.cpp: In member function ‘virtual int openfam::Fam_CIS_Direct::get_atomic(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, const char*, uint32_t, uint64_t, uint32_t, uint32_t)’:
/home/rajakr/development/OpenFAM/src/cis/fam_cis_direct.cpp:1052:31: error: qualified-id in declaration before ‘(’ token
 int Fam_CIS_Direct::put_atomic(uint64_t regionId, uint64_t srcOffset,
                               ^
/home/rajakr/development/OpenFAM/src/cis/fam_cis_direct.cpp:1092:1: error: expected ‘}’ at end of input
 } // namespace openfam
 ^