### PR TITLE
Removing cmake OpenFAM model variable from CMakeLists.txt file 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ include_directories(/usr/local/include)
 # To use the following OpenFAM options set USE_FAM_OPTION flag
 set( TEST_RUNTIME "PMIX" )
 set( TEST_NPE 1 ) #Number of pe used with mpirun
-set( TEST_OPENFAM_MODEL "memory_server" )
 set( TEST_DEFAULT_REGION "Default" )
 set( TEST_CIS_SERVER "127.0.0.1" )
 set( TEST_GRPC_PORT "8787" )
@@ -151,15 +150,6 @@ ENDIF()
 set( TEST_ENABLE_KNOWN_ISSUES "no" )
 if (ENABLE_KNOWN_ISSUES)
         set( TEST_ENABLE_KNOWN_ISSUES "yes" )
-endif()
-
-if (ARG_OPENFAM_MODEL)
-        set( TEST_OPENFAM_MODEL ${ARG_OPENFAM_MODEL})
-endif()
-
-if (${TEST_OPENFAM_MODEL} STREQUAL "shared_memory")
-        message(STATUS "Building shared memory model")
-        add_definitions(-DSHM)
 endif()
 
 if (USE_FAM_PERSIST)

--- a/test/common/fam_test_config.h.in
+++ b/test/common/fam_test_config.h.in
@@ -67,8 +67,8 @@ void init_fam_options(Fam_Options *famOpts) {
 memset((void *)famOpts, 0, sizeof(Fam_Options));
 
 #ifndef USE_CONFIG_OPTIONS
-    famOpts->openFamModel = strdup(TEST_OPENFAM_MODEL);
     // Read this from pe_config file.
+    //famOpts->openFamModel = strdup(TEST_OPENFAM_MODEL);
     //famOpts->cisInterfaceType = strdup(TEST_CIS_INTERFACE_TYPE);
     famOpts->cisServer = strdup(TEST_CIS_SERVER);
     famOpts->grpcPort = strdup(TEST_GRPC_PORT);


### PR DESCRIPTION
As it was taking precedence over config file parameter and build_and_test.sh
script fails to run shared memory model