### PR TITLE
Fix fam_metadata_test: Move initialization of metadata service

### DIFF
--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -56,7 +56,7 @@ sleep 5
 echo "=============================================================="
 echo "Test OpenFAM with cis-rpc-meta-direct-mem-direct configuration"
 echo "=============================================================="
-CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-cis-rpc-meta-rpc-mem-rpc
+CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-cis-rpc-meta-direct-mem-direct
 python3 $SCRIPT_DIR/run_test.py $LAUNCHER -n 1 --cisinterface rpc --cisrpcaddr 127.0.0.1:8787 --memserverinterface direct --metaserverinterface direct $CURRENTDIR $CONFIG_OUT_DIR $BUILD_DIR
 
 if [[ $? > 0 ]]
@@ -70,7 +70,7 @@ sleep 5
 echo "==========================================================="
 echo "Test OpenFAM with cis-direct-meta-rpc-mem-rpc configuration"
 echo "==========================================================="
-CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-cis-rpc-meta-rpc-mem-rpc
+CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-cis-direct-meta-rpc-mem-rpc
 python3 $SCRIPT_DIR/run_test.py $LAUNCHER -n 1 --cisinterface direct --memserverinterface rpc --metaserverinterface rpc --memserverlist 0:127.0.0.1:8789 --metaserverlist 0:127.0.0.1:8788 $CURRENTDIR $CONFIG_OUT_DIR $BUILD_DIR
 
 if [[ $? > 0 ]]

--- a/scripts/run_test.py
+++ b/scripts/run_test.py
@@ -342,12 +342,13 @@ def terminate_services():
 		    cmd = 'pkill cis_server'
 	    os.system(cmd)
 
+    time.sleep(5) # sufficient time to terminate the services
 
 #Run regression and unit tests
 cmd = 'cd '+args.buildpath+'; '+env_cmd+' make reg-test'
 result = os.system(cmd)
 if((result >> 8) != 0) :
-    print("\033[1;31;40mERROR: Regrresion test failed \033[0;37;40m")
+    print("\033[1;31;40mERROR: Regression test failed \033[0;37;40m")
     terminate_services()
     sys.exit(1)
 cmd = 'cd '+args.buildpath+'; '+env_cmd+' make unit-test'

--- a/test/unit-test/metadata/fam_metadata_test.cpp
+++ b/test/unit-test/metadata/fam_metadata_test.cpp
@@ -47,8 +47,6 @@ using namespace openfam;
 
 int main(int argc, char *argv[]) {
 
-    Fam_Metadata_Service *manager = new Fam_Metadata_Service_Direct(true);
-
     uint64_t count = 0, fail = 0;
 
     fam *my_fam = new fam();
@@ -75,6 +73,8 @@ int main(int argc, char *argv[]) {
                   << TEST_SKIP_STATUS << std::endl;
         return TEST_SKIP_STATUS;
     }
+
+    Fam_Metadata_Service *manager = new Fam_Metadata_Service_Direct(true);
 
     Fam_Region_Descriptor *desc[2];
     Fam_Region_Metadata node;


### PR DESCRIPTION
    Move initialization of metadata service in fam_metadata_test to after shared memory check.
    Fixed other minor typos in scripts.