### PR TITLE
Sync issue for ATL parallel test for put/get, cis server crashes for CIS RPC

### DIFF
--- a/src/common/atomic_queue.h
+++ b/src/common/atomic_queue.h
@@ -139,6 +139,7 @@ extern tInfo atomicTInfo[MAX_ATOMIC_THREADS];
 extern Fam_Ops_Libfabric *famOpsLibfabricQ;
 void *process_queue(void *);
 extern void *atomicRegionIdRoot;
+extern pthread_rwlock_t fiAddrLock;
 
 enum ATLError {
     ATOMIC_QUEUE_EMPTY = 100,


### PR DESCRIPTION
fixes for #113 

CIS server crashes as:
Program terminated with signal 11, Segmentation fault.
#0  openfam::process_queue (arg=0x82fa70 <openfam::atomicTInfo+16>)
    at /home/rajakr/openfam-devel/src/common/atomic_queue.cpp:516
516                     fiAddr = fiAddrV[0];
Missing separate debuginfos, use: debuginfo-install glibc-2.17-307.el7.1.x86_64 keyutils-libs-1.5.8-3.el7.x86_64 krb5-libs-1.15.1-46.el7.x86_64 libcom_err-1.42.9-17.el7.x86_64 libgcc-4.8.5-39.el7.x86_64 libibverbs-22.4-4.el7_8.x86_64 libnl3-3.2.28-4.el7.x86_64 librdmacm-22.4-4.el7_8.x86_64 libselinux-2.5-15.el7.x86_64 libstdc++-4.8.5-39.el7.x86_64 numactl-libs-2.0.12-5.el7.x86_64 openssl-libs-1.0.2k-19.el7.x86_64 pcre-8.32-17.el7.x86_64 yaml-cpp-0.5.1-2.el7.x86_64 zlib-1.2.7-18.el7.x86_64
(gdb) bt
#0  openfam::process_queue (arg=0x82fa70 <openfam::atomicTInfo+16>)
    at /home/rajakr/openfam-devel/src/common/atomic_queue.cpp:516
#1  0x00007f7d9ea6aea5 in start_thread () from /lib64/libpthread.so.0
#2  0x00007f7d9e7938dd in clone () from /lib64/libc.so.6
(gdb)