### PR TITLE
Fix for Github issue #165 Reduce initial size for metadata region

### DIFF
--- a/src/metadata_service/fam_metadata_service_direct.cpp
+++ b/src/metadata_service/fam_metadata_service_direct.cpp
@@ -704,8 +704,16 @@ void Fam_Metadata_Service_Direct::Impl_::metadata_insert_region(
 
     // Insert region name -> region id mapping in regionDataKVS
     ret = insert_in_regionname_kvs(regionName, regionKey);
-    //Fix for Github issue number 165 https://github.com/OpenFAM/OpenFAM/issues/165
 
+/** The logic for setting initial size for metadata region: 
+ *  - The initial size for metadata region is set by multiplying the size of one
+ *    data item by MAX_DATAITEM_NUM_HINT, which provides a hint regarding the 
+ *    maximum data items that may be created. 
+ *  - The initial size is then compared to 1/4th of the region size and the
+ *    minimum of the two is selected.  
+ *  - It is again compared to  MIN_HEAP_SIZE and the larger of the two is set
+ *    as the initial size for metadata region.
+ */
     size_t tmpSize = MAX_DATAITEM_NUM_HINT * sizeof(region) ;
     tmpSize =  (tmpSize < ((region->size)/4)) ? tmpSize : (region->size)/4;
     tmpSize = (tmpSize < MIN_HEAP_SIZE ? MIN_HEAP_SIZE : tmpSize);

--- a/src/metadata_service/fam_metadata_service_direct.cpp
+++ b/src/metadata_service/fam_metadata_service_direct.cpp
@@ -706,15 +706,15 @@ void Fam_Metadata_Service_Direct::Impl_::metadata_insert_region(
     ret = insert_in_regionname_kvs(regionName, regionKey);
 
 /** The logic for setting initial size for metadata region: 
- *  - The initial size for metadata region is set by multiplying the size of one
- *    data item by MAX_DATAITEM_NUM_HINT, which provides a hint regarding the 
- *    maximum data items that may be created. 
+ *  - The initial size for metadata region is set by multiplying the size of the
+ *    metadata for one data item by MAX_DATAITEM_NUM_HINT, which provides a hint
+ *    regarding the  maximum data items that may be created. 
  *  - The initial size is then compared to 1/4th of the region size and the
  *    minimum of the two is selected.  
  *  - It is again compared to  MIN_HEAP_SIZE and the larger of the two is set
  *    as the initial size for metadata region.
  */
-    size_t tmpSize = MAX_DATAITEM_NUM_HINT * sizeof(region) ;
+    size_t tmpSize = MAX_DATAITEM_NUM_HINT * sizeof(Fam_DataItem_Metadata) ;
     tmpSize =  (tmpSize < ((region->size)/4)) ? tmpSize : (region->size)/4;
     tmpSize = (tmpSize < MIN_HEAP_SIZE ? MIN_HEAP_SIZE : tmpSize);
 

--- a/src/metadata_service/fam_metadata_service_direct.cpp
+++ b/src/metadata_service/fam_metadata_service_direct.cpp
@@ -704,8 +704,12 @@ void Fam_Metadata_Service_Direct::Impl_::metadata_insert_region(
 
     // Insert region name -> region id mapping in regionDataKVS
     ret = insert_in_regionname_kvs(regionName, regionKey);
-    size_t tmpSize = region->size / 4;
+    //Fix for Github issue number 165 https://github.com/OpenFAM/OpenFAM/issues/165
+
+    size_t tmpSize = MAX_DATAITEM_NUM_HINT * sizeof(region) ;
+    tmpSize =  (tmpSize < ((region->size)/4)) ? tmpSize : (region->size)/4;
     tmpSize = (tmpSize < MIN_HEAP_SIZE ? MIN_HEAP_SIZE : tmpSize);
+
     if (ret == META_NO_ERROR) {
         // Region key does not exist, create an entry
 

--- a/src/metadata_service/fam_metadata_service_direct.h
+++ b/src/metadata_service/fam_metadata_service_direct.h
@@ -52,8 +52,6 @@
 #include "nvmm/memory_manager.h"
 #define MIN_HEAP_SIZE (64 * (1UL << 20))
 
-// Hint for maximum number of data items is set to 1 Million as part of fix for
-// Github issue number 165 https://github.com/OpenFAM/OpenFAM/issues/165
 #define MAX_DATAITEM_NUM_HINT 1000000
 
 using namespace radixtree;

--- a/src/metadata_service/fam_metadata_service_direct.h
+++ b/src/metadata_service/fam_metadata_service_direct.h
@@ -51,6 +51,11 @@
 #include "nvmm/fam.h"
 #include "nvmm/memory_manager.h"
 #define MIN_HEAP_SIZE (64 * (1UL << 20))
+
+// Hint for maximum number of data items is set to 1 Million as part of fix for
+// Github issue number 165 https://github.com/OpenFAM/OpenFAM/issues/165
+#define MAX_DATAITEM_NUM_HINT 1000000
+
 using namespace radixtree;
 using namespace nvmm;
 using namespace std;


### PR DESCRIPTION
Fix for Github issue #165 Reduce initial size for metadata region 
Changed the logic for setting initial size for metadata region.  The earlier logic was to set it to 1/4th of the region size.  Now, introduced a macro MAX_DATAITEM_NUM_HINT which is a hint that a maximum of 1 million data items may be created.  Multiplying that by the size of region, we will set the initial size.  It is then compared to 1/4th of the region size, using a conditional operator and the minimum of the two is selected.  It is again compared to the MIN_HEAP_SIZE and the larger of the two is set as the initial size for metadata region.
Tested by creating regions of different sizes upto 8TB using 8 memory servers and it is working as expected.
Regression tests were also run with these changes and all the 45 tests have passed.
