### PR TITLE
Test file fam_create_region API changes

### DIFF
--- a/test/apps/OSB_GUPs/GUPS_common.h
+++ b/test/apps/OSB_GUPs/GUPS_common.h
@@ -100,7 +100,7 @@ Fam_Region_Descriptor *GUPS_fam_initialize(size_t size) {
     }
 
     try {
-        region = my_fam->fam_create_region(REGION_NAME, size, 0777, NONE);
+        region = my_fam->fam_create_region(REGION_NAME, size, 0777, NULL);
     } catch (Fam_Exception &e) {
         cout << "fam create region failed 3:" << e.fam_error_msg() << endl;
         exit(1);

--- a/test/apps/pagerank/pagerank_common.h
+++ b/test/apps/pagerank/pagerank_common.h
@@ -162,7 +162,7 @@ Fam_Region_Descriptor *spmv_fam_initialize(size_t size) {
         // ignore
     }
     try {
-        region = my_fam->fam_create_region(REGION_NAME, size, 0777, NONE);
+        region = my_fam->fam_create_region(REGION_NAME, size, 0777, NULL);
     } catch (Fam_Exception &e) {
         cout << "fam initialization failed:" << e.fam_error_msg() << endl;
         exit(1);

--- a/test/common/fam_test_config.h.in
+++ b/test/common/fam_test_config.h.in
@@ -39,8 +39,7 @@
 #include <fam/fam.h>
 
 /*TO DO :: Change the create_region API in all tests and remove these macros*/
-#define RAID1 NULL
-#define RAID5 NULL
+//#define RAID5 NULL
 #define NONE NULL
 
 using namespace std;

--- a/test/common/fam_test_config.h.in
+++ b/test/common/fam_test_config.h.in
@@ -38,10 +38,6 @@
 #include <string.h>
 #include <fam/fam.h>
 
-/*TO DO :: Change the create_region API in all tests and remove these macros*/
-//#define RAID5 NULL
-#define NONE NULL
-
 using namespace std;
 using namespace openfam;
 // Fam_Options

--- a/test/maxconfig/fam-api-maxconfig/fam_mm_maxconfig_test.cpp
+++ b/test/maxconfig/fam-api-maxconfig/fam_mm_maxconfig_test.cpp
@@ -50,7 +50,7 @@ TEST(FamMMTest, FamCreateRegionMaxSizeSuccess) {
     const char *testRegion = get_uniq_str("mmtest", my_fam);
 
     EXPECT_NO_THROW(desc = my_fam->fam_create_region(testRegion, REG_MAX_SIZE,
-                                                     0777, RAID1));
+                                                     0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
     delete desc;
@@ -61,7 +61,7 @@ TEST(FamMMNegativeTest, FamCreateRegionGreaterMaxSizeFailure) {
     const char *testRegion = get_uniq_str("mm_negative_test", my_fam);
 
     EXPECT_THROW(
-        my_fam->fam_create_region(testRegion, 2199023255552, 0777, RAID1),
+        my_fam->fam_create_region(testRegion, 2199023255552, 0777, NULL),
         Fam_Exception);
     free((void *)testRegion);
 }
@@ -73,7 +73,7 @@ TEST(FamMMTest, FamAllocateMaxSizeSuccess) {
     const char *dataItem = get_uniq_str("mm_data", my_fam);
 
     EXPECT_NO_THROW(desc = my_fam->fam_create_region(testRegion, REG_MAX_SIZE,
-                                                     0777, RAID1));
+                                                     0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(
         item = my_fam->fam_allocate(dataItem, 549755813888, 0444, desc));
@@ -93,7 +93,7 @@ TEST(FamMMNegativeTest, FamAllocateGreaterMaxSizeFailure) {
     const char *dataItem = get_uniq_str("mm_data", my_fam);
 
     EXPECT_NO_THROW(desc = my_fam->fam_create_region(testRegion, REG_MAX_SIZE,
-                                                     0777, RAID1));
+                                                     0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_THROW(my_fam->fam_allocate(dataItem, 824633720832, 0444, desc),
                  Fam_Exception);

--- a/test/microbench/fam-api-mb/fam_microbenchmark.cpp
+++ b/test/microbench/fam-api-mb/fam_microbenchmark.cpp
@@ -87,7 +87,7 @@ TEST(FamCreateDestroyRegion, FamCreateDestroyRegionMultiple1) {
         char regionInfo[NAME_BUFF_SIZE];
         sprintf(regionInfo, "%s_%d", testRegionLocal, i);
         EXPECT_NO_THROW(descLocal[i] = my_fam->fam_create_region(
-                            regionInfo, BLOCK_SIZE, 0777, RAID1));
+                            regionInfo, BLOCK_SIZE, 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal[i]);
     }
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -112,7 +112,7 @@ TEST(FamCreateDestroyRegion, FamCreateRegionMultiple2) {
         char regionInfo[NAME_BUFF_SIZE];
         sprintf(regionInfo, "%s_%d", testRegionLocal, i);
         EXPECT_NO_THROW(descLocal[i] = my_fam->fam_create_region(
-                            regionInfo, BLOCK_SIZE, 0777, RAID1));
+                            regionInfo, BLOCK_SIZE, 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal[i]);
     }
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -156,7 +156,7 @@ TEST(FamCreateDestroyRegion, FamCreateDestroyRegionChngPermissions) {
         perm = (mode_t)i;
         sprintf(regionInfo, "%s_%d", testRegionLocal, i);
         EXPECT_NO_THROW(descLocal[i] = my_fam->fam_create_region(
-                            regionInfo, BLOCK_SIZE, perm, RAID1));
+                            regionInfo, BLOCK_SIZE, perm, NULL));
         EXPECT_NE((void *)NULL, descLocal[i]);
     }
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -174,7 +174,7 @@ TEST(FamAllocateDellocate, FamAllocateDellocateMultiple1) {
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
 
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     for (int i = 0; i < NUM_MM_ITERATIONS; i++) {
@@ -205,7 +205,7 @@ TEST(FamAllocateDeallocate, FamAllocateMultiple2) {
     const char *firstItemLocal = get_uniq_str("firstLocal", my_fam);
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     EXPECT_NO_THROW(item1 = my_fam->fam_allocate(firstItemLocal, DATA_ITEM_SIZE,
@@ -235,7 +235,7 @@ TEST(FamAllocateDeallocate, FamAllocateSingleRegion) {
     const char *firstItemLocal = get_uniq_str("firstLocal", my_fam);
     if (*myPE == 0) {
         EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                            "test", BIG_REGION_SIZE, 0777, RAID1));
+                            "test", BIG_REGION_SIZE, 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal);
     }
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -327,7 +327,7 @@ TEST(FamChangePermissions, DataItemChangePermission) {
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
     const char *firstItemLocal = get_uniq_str("firstLocal", my_fam);
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     // Allocating data items
@@ -357,7 +357,7 @@ TEST(FamChangePermissions, RegionChangePermission) {
     Fam_Region_Descriptor *descLocal;
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -513,7 +513,7 @@ TEST(FamAllocator, FamCreateRegion) {
         char regionInfo[NAME_BUFF_SIZE];
         sprintf(regionInfo, "%s_%d", testRegionLocal, i);
         EXPECT_NO_THROW(descLocal[i] = my_fam->fam_create_region(
-                            regionInfo, BLOCK_SIZE, 0777, RAID1));
+                            regionInfo, BLOCK_SIZE, 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal[i]);
     }
     free((void *)testRegionLocal);
@@ -544,7 +544,7 @@ TEST(FamAllocator, FamAllocateItem) {
     const char *firstItemLocal = get_uniq_str("firstLocal", my_fam);
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     for (int i = 0; i < NUM_MM_ITERATIONS; i++) {
@@ -612,7 +612,7 @@ TEST(FamAllocator, FamResizeRegion) {
     Fam_Region_Descriptor *descLocal;
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, RESIZE_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, RESIZE_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -641,7 +641,7 @@ TEST(FamCopy, FamCopyAndWait) {
     char *local = strdup("Test message");
 
     EXPECT_NO_THROW(srcRegion = my_fam->fam_create_region(
-                        firstRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        firstRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, srcRegion);
 
     for (int i = 0; i < NUM_MM_ITERATIONS; i++) {
@@ -659,7 +659,7 @@ TEST(FamCopy, FamCopyAndWait) {
     const char *secondRegionLocal = get_uniq_str("secondRegionLocal", my_fam);
 
     EXPECT_NO_THROW(destRegion = my_fam->fam_create_region(
-                        secondRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        secondRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, destRegion);
 
     for (int i = 0; i < NUM_MM_ITERATIONS; i++) {
@@ -2528,7 +2528,7 @@ int main(int argc, char **argv) {
     const char *testRegion = get_uniq_str("testGlobal", my_fam);
 
     EXPECT_NO_THROW(desc = my_fam->fam_create_region(
-                        testRegion, SMALL_REGION_SIZE, 0777, RAID1));
+                        testRegion, SMALL_REGION_SIZE, 0777, NULL));
     test_perm_mode = ALL_PERM;
     test_item_size = BLOCK_SIZE * NUM_ITERATIONS;
     // Allocating data global item

--- a/test/microbench/fam-api-mb/fam_microbenchmark_128_compare_swap.cpp
+++ b/test/microbench/fam-api-mb/fam_microbenchmark_128_compare_swap.cpp
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
     const char *testRegion = get_uniq_str("testGlobal", my_fam);
 
     EXPECT_NO_THROW(desc = my_fam->fam_create_region(
-                        testRegion, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegion, BIG_REGION_SIZE, 0777, NULL));
     test_perm_mode = ALL_PERM;
     test_item_size = BLOCK_SIZE;
     // Allocating data items in the created region

--- a/test/microbench/fam-api-mb/fam_microbenchmark_allocator.cpp
+++ b/test/microbench/fam-api-mb/fam_microbenchmark_allocator.cpp
@@ -81,7 +81,7 @@ TEST(FamCreateDestroyRegion, FamCreateDestroyRegionMultiple1) {
         char regionInfo[NAME_BUFF_SIZE];
         sprintf(regionInfo, "%s_%d", testRegionLocal, i);
         EXPECT_NO_THROW(descLocal[i] = my_fam->fam_create_region(
-                            regionInfo, BLOCK_SIZE, 0777, RAID1));
+                            regionInfo, BLOCK_SIZE, 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal[i]);
     }
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -106,7 +106,7 @@ TEST(FamCreateDestroyRegion, FamCreateRegionMultiple2) {
         char regionInfo[NAME_BUFF_SIZE];
         sprintf(regionInfo, "%s_%d", testRegionLocal, i);
         EXPECT_NO_THROW(descLocal[i] = my_fam->fam_create_region(
-                            regionInfo, BLOCK_SIZE, 0777, RAID1));
+                            regionInfo, BLOCK_SIZE, 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal[i]);
     }
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -149,7 +149,7 @@ TEST(FamCreateDestroyRegion, FamCreateDestroyRegionChngPermissions) {
         perm = (mode_t)i;
         sprintf(regionInfo, "%s_%d", testRegionLocal, i);
         EXPECT_NO_THROW(descLocal[i] = my_fam->fam_create_region(
-                            regionInfo, BLOCK_SIZE, perm, RAID1));
+                            regionInfo, BLOCK_SIZE, perm, NULL));
         EXPECT_NE((void *)NULL, descLocal[i]);
     }
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -167,7 +167,7 @@ TEST(FamAllocateDellocate, FamAllocateDellocateMultiple1) {
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
 
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     for (int i = 0; i < NUM_MM_ITERATIONS; i++) {
@@ -198,7 +198,7 @@ TEST(FamAllocateDeallocate, FamAllocateMultiple2) {
     const char *firstItemLocal = get_uniq_str("firstLocal", my_fam);
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     EXPECT_NO_THROW(item1 = my_fam->fam_allocate(firstItemLocal, DATA_ITEM_SIZE,
@@ -228,7 +228,7 @@ TEST(FamAllocateDeallocate, FamAllocateSingleRegion) {
     const char *firstItemLocal = get_uniq_str("firstLocal", my_fam);
     if (*myPE == 0) {
         EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                            "test", BIG_REGION_SIZE, 0777, RAID1));
+                            "test", BIG_REGION_SIZE, 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal);
     }
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -324,7 +324,7 @@ TEST(FamChangePermissions, DataItemChangePermission) {
     }
     catch (Fam_Exception &e) {
         EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                            testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                            testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     }
     EXPECT_NE((void *)NULL, descLocal);
 
@@ -355,7 +355,7 @@ TEST(FamChangePermissions, RegionChangePermission) {
     Fam_Region_Descriptor *descLocal;
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -389,7 +389,7 @@ TEST(FamLookup, FamLookupRegion) {
         }
         catch (Fam_Exception &e) {
             EXPECT_NO_THROW(desc2 = my_fam->fam_create_region(
-                                regionInfo, BIG_REGION_SIZE, 0777, RAID1));
+                                regionInfo, BIG_REGION_SIZE, 0777, NULL));
         }
         EXPECT_NE((void *)NULL, desc2);
         free(regionInfo);
@@ -453,7 +453,7 @@ TEST(FamAllocator, FamResizeRegion) {
     Fam_Region_Descriptor *descLocal;
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, RESIZE_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, RESIZE_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -482,7 +482,7 @@ TEST(FamCopy, FamCopyAndWait) {
     char *local = strdup("Test message");
 
     EXPECT_NO_THROW(srcRegion = my_fam->fam_create_region(
-                        firstRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        firstRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, srcRegion);
 
     for (int i = 0; i < NUM_MM_ITERATIONS; i++) {
@@ -500,7 +500,7 @@ TEST(FamCopy, FamCopyAndWait) {
     const char *secondRegionLocal = get_uniq_str("secondRegionLocal", my_fam);
 
     EXPECT_NO_THROW(destRegion = my_fam->fam_create_region(
-                        secondRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        secondRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, destRegion);
 
     for (int i = 0; i < NUM_MM_ITERATIONS; i++) {

--- a/test/microbench/fam-api-mb/fam_microbenchmark_atomic.cpp
+++ b/test/microbench/fam-api-mb/fam_microbenchmark_atomic.cpp
@@ -314,7 +314,7 @@ int main(int argc, char **argv) {
 
     EXPECT_NO_THROW(myPE = (int *)my_fam->fam_get_option(strdup("PE_ID")));
     EXPECT_NO_THROW(desc = my_fam->fam_create_region(
-                        testRegion, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegion, BIG_REGION_SIZE, 0777, NULL));
     test_perm_mode = ALL_PERM;
     test_item_size = BLOCK_SIZE;
     // Allocating data items in the created region

--- a/test/microbench/fam-api-mb/fam_microbenchmark_datapath.cpp
+++ b/test/microbench/fam-api-mb/fam_microbenchmark_datapath.cpp
@@ -333,7 +333,7 @@ int main(int argc, char **argv) {
 
     EXPECT_NO_THROW(myPE = (int *)my_fam->fam_get_option(strdup("PE_ID")));
     EXPECT_NO_THROW(desc = my_fam->fam_create_region(
-                        testRegion, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegion, BIG_REGION_SIZE, 0777, NULL));
 
     test_perm_mode = ALL_PERM;
     test_item_size = gDataSize * 4;

--- a/test/microbench/fam-api-mb/fam_region_spanning.cpp
+++ b/test/microbench/fam-api-mb/fam_region_spanning.cpp
@@ -509,7 +509,7 @@ int main(int argc, char **argv) {
         uint64_t regionSize = gDataSize * NUM_DATAITEMS * *numPEs;
         regionSize = regionSize < BIG_REGION_SIZE ? BIG_REGION_SIZE : regionSize;
         EXPECT_NO_THROW(descLocal =
-                  my_fam->fam_create_region("test0", regionSize , 0777, RAID1));
+                  my_fam->fam_create_region("test0", regionSize , 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal);
     }
 

--- a/test/microbench/fam-api-mb/fam_region_spanning_atomic.cpp
+++ b/test/microbench/fam-api-mb/fam_region_spanning_atomic.cpp
@@ -549,7 +549,7 @@ int main(int argc, char **argv) {
 	uint64_t regionSize = gDataSize * NUM_DATAITEMS * *numPEs;
 	regionSize = regionSize < BIG_REGION_SIZE ? BIG_REGION_SIZE : regionSize;
 	EXPECT_NO_THROW(descLocal = 
-		  my_fam->fam_create_region("test0", regionSize , 0777, RAID1));
+		  my_fam->fam_create_region("test0", regionSize , 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal);
     }
    

--- a/test/multi-memnode-test/fam_datapath_for_memnode_regions.cpp
+++ b/test/multi-memnode-test/fam_datapath_for_memnode_regions.cpp
@@ -187,7 +187,7 @@ int main(int argc, char **argv) {
             const char *testRegion = getRegionName(i, numsrv);
 
             EXPECT_NO_THROW(testRegionDesc[i] = my_fam->fam_create_region(
-                                testRegion, REGION_SIZE, REGION_PERM, RAID1));
+                                testRegion, REGION_SIZE, REGION_PERM, NULL));
             EXPECT_NE((void *)NULL, testRegionDesc[i]);
             cout << "PE ID: " << *peId << "Region with name " << testRegion
                  << " created in memory node : "

--- a/test/multi-memnode-test/fam_datapath_for_random_regions.cpp
+++ b/test/multi-memnode-test/fam_datapath_for_random_regions.cpp
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
         sprintf(itemStr, "%s_%d", firstItem, i);
         EXPECT_NO_THROW(
             testRegionDesc[i] = my_fam->fam_create_region(
-                regionStr, REGION_SIZE + 1048576, REGION_PERM, RAID1));
+                regionStr, REGION_SIZE + 1048576, REGION_PERM, NULL));
         EXPECT_NE((void *)NULL, testRegionDesc[i]);
         cout << "Region with name " << regionStr << " created in memory node : "
              << testRegionDesc[i]->get_memserver_id() <<  endl;

--- a/test/multi-memnode-test/fam_microbenchmark_atomic_multiple_memnodes.cpp
+++ b/test/multi-memnode-test/fam_microbenchmark_atomic_multiple_memnodes.cpp
@@ -341,7 +341,7 @@ int main(int argc, char **argv) {
 
     if ((*peId % numsrv) == *peId) {
         EXPECT_NO_THROW(desc = my_fam->fam_create_region(
-                            testRegion, BIG_REGION_SIZE, 0777, RAID1));
+                            testRegion, BIG_REGION_SIZE, 0777, NULL));
         my_fam->fam_barrier_all();
 
     } else {

--- a/test/multi-memnode-test/fam_microbenchmark_datapath_multiple_memnodes.cpp
+++ b/test/multi-memnode-test/fam_microbenchmark_datapath_multiple_memnodes.cpp
@@ -288,7 +288,7 @@ int main(int argc, char **argv) {
     // the same region.
     if ((*peId % numsrv) == *peId) {
         EXPECT_NO_THROW(desc = my_fam->fam_create_region(
-                            testRegion, BIG_REGION_SIZE, 0777, RAID1));
+                            testRegion, BIG_REGION_SIZE, 0777, NULL));
         my_fam->fam_barrier_all();
 
     } else {

--- a/test/multi-memnode-test/fam_multi_memnode_tests.cpp
+++ b/test/multi-memnode-test/fam_multi_memnode_tests.cpp
@@ -60,35 +60,35 @@ TEST(FamMultiMemNode, RandomNames) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc[0] = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc[0] = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     cout << "Region with name " << testRegion
          << " created in memory node : " << desc[0]->get_memserver_id() << endl;
 
     EXPECT_NO_THROW(
-        desc[1] = my_fam->fam_create_region(testRegion2, 8192, 0777, RAID1));
+        desc[1] = my_fam->fam_create_region(testRegion2, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     cout << "Region with name " << testRegion2
          << " created in memory node : " << desc[1]->get_memserver_id() << endl;
 
     EXPECT_NO_THROW(
-        desc[2] = my_fam->fam_create_region(testRegion3, 8192, 0777, RAID1));
+        desc[2] = my_fam->fam_create_region(testRegion3, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     cout << "Region with name " << testRegion3
          << " created in memory node : " << desc[2]->get_memserver_id() << endl;
 
     EXPECT_NO_THROW(
-        desc[3] = my_fam->fam_create_region(testRegion4, 8192, 0777, RAID1));
+        desc[3] = my_fam->fam_create_region(testRegion4, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     cout << "Region with name " << testRegion4
          << " created in memory node : " << desc[3]->get_memserver_id() << endl;
 
     EXPECT_NO_THROW(
-        desc[4] = my_fam->fam_create_region(testRegion5, 8192, 0777, RAID1));
+        desc[4] = my_fam->fam_create_region(testRegion5, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     cout << "Region with name " << testRegion5
@@ -133,7 +133,7 @@ TEST(FamMultiMemNode, SequentialSuffixName) {
         char regionInfo[NAME_BUFF_SIZE];
         sprintf(regionInfo, "%s_%d", testRegion, i);
         EXPECT_NO_THROW(
-            desc[i] = my_fam->fam_create_region(regionInfo, 8192, 0777, RAID1));
+            desc[i] = my_fam->fam_create_region(regionInfo, 8192, 0777, NULL));
         EXPECT_NE((void *)NULL, desc);
         cout << "Region with name " << regionInfo
              << " created in memory node : " << desc[i]->get_memserver_id()
@@ -158,7 +158,7 @@ TEST(FamMultiMemNode, RandomSuffixName) {
         char regionInfo[NAME_BUFF_SIZE];
         sprintf(regionInfo, "%s_%ld", testRegion, random());
         EXPECT_NO_THROW(
-            desc[i] = my_fam->fam_create_region(regionInfo, 8192, 0777, RAID1));
+            desc[i] = my_fam->fam_create_region(regionInfo, 8192, 0777, NULL));
         EXPECT_NE((void *)NULL, desc);
         cout << "Region with name " << regionInfo
              << " created in memory node : " << desc[i]->get_memserver_id()

--- a/test/permission-test/fam-mm-permission-multi-user/fam_create_region.cpp
+++ b/test/permission-test/fam-mm-permission-multi-user/fam_create_region.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
     }
 
     try {
-	my_fam->fam_create_region(argv[1], atoi(argv[2]), (mode_t)strtol(argv[3], NULL, 8), RAID1);
+	my_fam->fam_create_region(argv[1], atoi(argv[2]), (mode_t)strtol(argv[3], NULL, 8), NULL);
     }
     catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;

--- a/test/reg-test/allocator-reg/fam_allocator_reg_test.cpp
+++ b/test/reg-test/allocator-reg/fam_allocator_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamAllocator, AllocatorSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/allocator-reg/fam_map_reg_test.cpp
+++ b/test/reg-test/allocator-reg/fam_map_reg_test.cpp
@@ -52,7 +52,7 @@ TEST(FamPutGet, PutGetSuccess) {
     void *base;
     char *local = strdup("Test message");
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/allocator-reg/fam_resize_reg_test.cpp
+++ b/test/reg-test/allocator-reg/fam_resize_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamResize, ResizeSuccess) {
     const char *testRegion = get_uniq_str("test1", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     uint64_t regionSize;
@@ -90,7 +90,7 @@ TEST(FamResize, MultiAllocationMultiResizeSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 1048576, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 1048576, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     uint64_t regionSize;
@@ -142,7 +142,7 @@ TEST(FamResize, MultiAllocationMultiResizeFail) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 1048576, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 1048576, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     uint64_t regionSize;
@@ -230,7 +230,7 @@ TEST(FamResize, MultiPeAllocationResizeSuccess) {
     if (((*myPE % 2) == 0) && !isLastOddPE) {
         sprintf(testRegion, "Test_%d", *myPE);
         EXPECT_NO_THROW(desc = my_fam->fam_create_region(testRegion, 16777216,
-                                                         0777, RAID1));
+                                                         0777, NULL));
         EXPECT_NE((void *)NULL, desc);
         int i = 0;
         while (1) {
@@ -285,7 +285,7 @@ TEST(FamResize, ResizeNoPerm) {
     const char *testRegion = get_uniq_str("test1", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0444, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0444, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Resizing the region

--- a/test/reg-test/fam-api-reg/fam_arithmatic_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_arithmatic_atomics_reg_test.cpp
@@ -716,7 +716,7 @@ int main(int argc, char **argv) {
     testRegionStr = get_uniq_str("test", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_arithmetic_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_arithmetic_atomics_mt_reg_test.cpp
@@ -757,7 +757,7 @@ int main(int argc, char **argv) {
     testRegionStr = get_uniq_str("test", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_atomics_reg_test.cpp
@@ -270,7 +270,7 @@ int main(int argc, char **argv) {
     testRegionStr = get_uniq_str("test", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_backup_restore_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_backup_restore_reg_test.cpp
@@ -316,7 +316,7 @@ int main(int argc, char **argv) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_barrier_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_barrier_reg_test.cpp
@@ -67,7 +67,7 @@ TEST(FamBarrierAll, BarrierAllSuccess) {
 
     if (*myPE == 0) {
         EXPECT_NO_THROW(
-            desc = my_fam->fam_create_region("test", 8192, 0777, RAID1));
+            desc = my_fam->fam_create_region("test", 8192, 0777, NULL));
         EXPECT_NE((void *)NULL, desc);
     }
 

--- a/test/reg-test/fam-api-reg/fam_cas_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_cas_atomics_mt_reg_test.cpp
@@ -361,7 +361,7 @@ int main(int argc, char **argv) {
     testRegionStr = get_uniq_str("test", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_cas_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_cas_atomics_reg_test.cpp
@@ -367,7 +367,7 @@ int main(int argc, char **argv) {
     testRegionStr = get_uniq_str("test", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_compare_swap_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_compare_swap_atomics_mt_reg_test.cpp
@@ -472,7 +472,7 @@ int main(int argc, char **argv) {
     testRegionStr = get_uniq_str("test", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
     ret = RUN_ALL_TESTS();
     EXPECT_NO_THROW(my_fam->fam_destroy_region(testRegionDesc));

--- a/test/reg-test/fam-api-reg/fam_compare_swap_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_compare_swap_atomics_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamCompareSwapInt32, CompareSwapInt32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -86,7 +86,7 @@ TEST(FamCompareSwapInt64, CompareSwapInt64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -121,7 +121,7 @@ TEST(FamCompareSwapUint32, CompareSwapUint32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -156,7 +156,7 @@ TEST(FamCompareSwapUint64, CompareSwapUint64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -191,7 +191,7 @@ TEST(FamCompareSwapInt128, CompareSwapInt128Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -254,7 +254,7 @@ TEST(FamCompareSwapNegativeCase, CompareSwapNegativeCaseSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -289,7 +289,7 @@ TEST(FamCompareSwapNegativeCaseInt128, CompareSwapNegativeCaseInt128Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_control_path_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_control_path_reg_test.cpp
@@ -60,7 +60,7 @@ TEST(FamControlPath, CreateDestroyRegion) {
         char regionInfo[NAME_BUFF_SIZE];
         sprintf(regionInfo, "%s_%d", testRegionLocal, i);
         EXPECT_NO_THROW(descLocal[i] = my_fam->fam_create_region(
-                            regionInfo, BLOCK_SIZE, 0777, RAID1));
+                            regionInfo, BLOCK_SIZE, 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal[i]);
     }
     EXPECT_NO_THROW(my_fam->fam_barrier_all());
@@ -78,7 +78,7 @@ TEST(FamControlPath, FamAllocateDellocateMultiple1) {
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
 
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     for (int i = 0; i < NUM_MM_ITERATIONS; i++) {
@@ -111,7 +111,7 @@ TEST(FamControlPath, RegionChangePermission) {
         char regionInfo[NAME_BUFF_SIZE];
         sprintf(regionInfo, "%s_%d", testRegionLocal, i);
         EXPECT_NO_THROW(descLocal[i] = my_fam->fam_create_region(
-                            regionInfo, BLOCK_SIZE, 0777, RAID1));
+                            regionInfo, BLOCK_SIZE, 0777, NULL));
         EXPECT_NE((void *)NULL, descLocal[i]);
         perm = (mode_t)i;
         my_fam->fam_change_permissions(descLocal[i], perm);
@@ -132,7 +132,7 @@ TEST(FamControlPath, DataItemChangePermission) {
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
 
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, BIG_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, BIG_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     mode_t perm;
@@ -160,7 +160,7 @@ TEST(FamControlPath, FamResizeRegion) {
     Fam_Region_Descriptor *descLocal;
     const char *testRegionLocal = get_uniq_str("testLocal", my_fam);
     EXPECT_NO_THROW(descLocal = my_fam->fam_create_region(
-                        testRegionLocal, RESIZE_REGION_SIZE, 0777, RAID1));
+                        testRegionLocal, RESIZE_REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, descLocal);
 
     EXPECT_NO_THROW(my_fam->fam_barrier_all());

--- a/test/reg-test/fam-api-reg/fam_copy_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_copy_reg_test.cpp
@@ -59,7 +59,7 @@ TEST(FamCopy, CopySuccess) {
     const char *destItemName = get_uniq_str("Dest_Itemt", my_fam);
 
     EXPECT_NO_THROW(
-        srcDesc = my_fam->fam_create_region(srcRegionName, 8192, 0777, RAID1));
+        srcDesc = my_fam->fam_create_region(srcRegionName, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, srcDesc);
 
     // Allocating data items in the created region
@@ -68,7 +68,7 @@ TEST(FamCopy, CopySuccess) {
     EXPECT_NE((void *)NULL, srcItem);
 
     EXPECT_NO_THROW(destDesc = my_fam->fam_create_region(destRegionName, 8192,
-                                                         0777, RAID1));
+                                                         0777, NULL));
     EXPECT_NE((void *)NULL, destDesc);
 
     for (int i = 0; i < MESSAGE_SIZE; i++) {
@@ -140,7 +140,7 @@ TEST(FamCopy, CopyFailSrcOutOfRange) {
     const char *destItemName = get_uniq_str("Dest_Itemt", my_fam);
 
     EXPECT_NO_THROW(
-        srcDesc = my_fam->fam_create_region(srcRegionName, 8192, 0777, RAID1));
+        srcDesc = my_fam->fam_create_region(srcRegionName, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, srcDesc);
 
     // Allocating data items in the created region
@@ -149,7 +149,7 @@ TEST(FamCopy, CopyFailSrcOutOfRange) {
     EXPECT_NE((void *)NULL, srcItem);
 
     EXPECT_NO_THROW(destDesc = my_fam->fam_create_region(destRegionName, 8192,
-                                                         0777, RAID1));
+                                                         0777, NULL));
     EXPECT_NE((void *)NULL, destDesc);
 
     // Allocating data items in the created region
@@ -192,7 +192,7 @@ TEST(FamCopy, CopyFailDstOutOfRange) {
     const char *destItemName = get_uniq_str("Dest_Itemt", my_fam);
 
     EXPECT_NO_THROW(
-        srcDesc = my_fam->fam_create_region(srcRegionName, 8192, 0777, RAID1));
+        srcDesc = my_fam->fam_create_region(srcRegionName, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, srcDesc);
 
     // Allocating data items in the created region
@@ -201,7 +201,7 @@ TEST(FamCopy, CopyFailDstOutOfRange) {
     EXPECT_NE((void *)NULL, srcItem);
 
     EXPECT_NO_THROW(destDesc = my_fam->fam_create_region(destRegionName, 8192,
-                                                         0777, RAID1));
+                                                         0777, NULL));
     EXPECT_NE((void *)NULL, destDesc);
 
     // Allocating data items in the created region
@@ -244,7 +244,7 @@ TEST(FamCopy, CopyFailLenOutOfRange) {
     const char *destItemName = get_uniq_str("Dest_Itemt", my_fam);
 
     EXPECT_NO_THROW(
-        srcDesc = my_fam->fam_create_region(srcRegionName, 8192, 0777, RAID1));
+        srcDesc = my_fam->fam_create_region(srcRegionName, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, srcDesc);
 
     // Allocating data items in the created region
@@ -253,7 +253,7 @@ TEST(FamCopy, CopyFailLenOutOfRange) {
     EXPECT_NE((void *)NULL, srcItem);
 
     EXPECT_NO_THROW(destDesc = my_fam->fam_create_region(destRegionName, 8192,
-                                                         0777, RAID1));
+                                                         0777, NULL));
     EXPECT_NE((void *)NULL, destDesc);
 
     // Allocating data items in the created region
@@ -297,7 +297,7 @@ TEST(FamCopy, CopyWithinSameRegionSuccess) {
     const char *destItemName = get_uniq_str("Dest_Item", my_fam);
 
     EXPECT_NO_THROW(srcDesc = my_fam->fam_create_region(srcRegionName, 819200,
-                                                        0777, RAID1));
+                                                        0777, NULL));
     EXPECT_NE((void *)NULL, srcDesc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_fence_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_fence_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamFence, FenceSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_fetch_arithmatic_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_fetch_arithmatic_atomics_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamArithAtomicInt32, ArithAtomicInt32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -102,7 +102,7 @@ TEST(FamArithAtomicInt64, ArithAtomicInt64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -154,7 +154,7 @@ TEST(FamArithAtomicUint32, ArithAtomicUint32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -212,7 +212,7 @@ TEST(FamArithAtomicUint64, ArithAtomicUint64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -270,7 +270,7 @@ TEST(FamArithAtomicFloat, ArithAtomiciFloatSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -322,7 +322,7 @@ TEST(FamArithAtomiciDouble, ArithAtomicDoubleSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_fetch_arithmetic_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_fetch_arithmetic_atomics_mt_reg_test.cpp
@@ -103,7 +103,7 @@ TEST(FamArithAtomicInt32, ArithAtomicInt32Success) {
     ValueInfo *info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -180,7 +180,7 @@ TEST(FamArithAtomicInt64, ArithAtomicInt64Success) {
     ValueInfo *info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -263,7 +263,7 @@ TEST(FamArithAtomicUint32, ArithAtomicUint32Success) {
     ValueInfo *info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -346,7 +346,7 @@ TEST(FamArithAtomicUint64, ArithAtomicUint64Success) {
     ValueInfo *info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -423,7 +423,7 @@ TEST(FamArithAtomicFloat, ArithAtomiciFloatSuccess) {
     ValueInfo *info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -500,7 +500,7 @@ TEST(FamArithAtomiciDouble, ArithAtomicDoubleSuccess) {
     ValueInfo *info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_fetch_logical_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_fetch_logical_atomics_mt_reg_test.cpp
@@ -133,7 +133,7 @@ TEST(FamLogicalAtomicUint32, LogicalAtomicUint32Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, 0777, RAID1));
+                        testRegionStr, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -235,7 +235,7 @@ TEST(FamLogicalAtomicUint64, LogicalAtomicUint64Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, 0777, RAID1));
+                        testRegionStr, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_fetch_logical_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_fetch_logical_atomics_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamLogicalAtomicUint32, LogicalAtomicUint32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -123,7 +123,7 @@ TEST(FamLogicalAtomicUint64, LogicalAtomicUint64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_fetch_min_max_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_fetch_min_max_atomics_mt_reg_test.cpp
@@ -100,7 +100,7 @@ TEST(FamMinMaxAtomicInt32, MinMaxAtomicInt32Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, 0777, RAID1));
+                        testRegionStr, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -169,7 +169,7 @@ TEST(FamMinMaxAtomicInt64, MinMaxAtomicInt64Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, 0777, RAID1));
+                        testRegionStr, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -238,7 +238,7 @@ TEST(FamMinMaxAtomicUint32, MinMaxAtomicUint32Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, 0777, RAID1));
+                        testRegionStr, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -306,7 +306,7 @@ TEST(FamMinMaxAtomicUint64, MinMaxAtomicUint64Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, 0777, RAID1));
+                        testRegionStr, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -374,7 +374,7 @@ TEST(FamMinMaxAtomicFloat, MinMaxAtomicFloatSuccess) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, 0777, RAID1));
+                        testRegionStr, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -442,7 +442,7 @@ TEST(FamMinMaxAtomicDouble, MinMaxAtomicDoubleSuccess) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, 0777, RAID1));
+                        testRegionStr, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_fetch_min_max_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_fetch_min_max_atomics_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamMinMaxAtomicInt32, MinMaxAtomicInt32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -91,7 +91,7 @@ TEST(FamMinMaxAtomicInt64, MinMaxAtomicInt64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -130,7 +130,7 @@ TEST(FamMinMaxAtomicUint32, MinMaxAtomicUint32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -169,7 +169,7 @@ TEST(FamMinMaxAtomicUint64, MinMaxAtomicUint64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -208,7 +208,7 @@ TEST(FamMinMaxAtomicFloat, MinMaxAtomicFloatSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -247,7 +247,7 @@ TEST(FamMinMaxAtomicDouble, MinMaxAtomicDoubleSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_invalid_offset_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_invalid_offset_reg_test.cpp
@@ -52,7 +52,7 @@ TEST(FamInvalidOffset, InvalidOffsetSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_invalidkey_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_invalidkey_reg_test.cpp
@@ -74,7 +74,7 @@ TEST(FamInvalidKey, InvalidKeySuccess) {
     EXPECT_NO_THROW(famOps->initialize());
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_logical_atomic_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_logical_atomic_reg_test.cpp
@@ -799,7 +799,7 @@ int main(int argc, char **argv) {
     openFamModel = (char *)my_fam->fam_get_option(strdup("OPENFAM_MODEL"));
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_min_max_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_min_max_atomics_mt_reg_test.cpp
@@ -1448,7 +1448,7 @@ int main(int argc, char **argv) {
     openFamModel = (char *)my_fam->fam_get_option(strdup("OPENFAM_MODEL"));
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
     ret = RUN_ALL_TESTS();
 

--- a/test/reg-test/fam-api-reg/fam_min_max_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_min_max_atomics_reg_test.cpp
@@ -1382,7 +1382,7 @@ int main(int argc, char **argv) {
     openFamModel = (char *)my_fam->fam_get_option(strdup("OPENFAM_MODEL"));
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_mm_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_mm_reg_test.cpp
@@ -50,7 +50,7 @@ TEST(FamMMTest, FamCreateDestroySuccess) {
     const char *testRegion = get_uniq_str("mmtest", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 4096, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 4096, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
     delete desc;
@@ -64,7 +64,7 @@ TEST(FamMMTest, FamAllocateDeallocateSuccess) {
     const char *dataItem = get_uniq_str("mm_data", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 4096, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 4096, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(item = my_fam->fam_allocate(dataItem, 1024, 0444, desc));
     EXPECT_NE((void *)NULL, item);
@@ -85,7 +85,7 @@ TEST(FamMMTest, FamAllocateDeallocateBignameSuccess) {
         get_uniq_str("testdatatestdatatestdatatestdatate", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 4096, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 4096, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(item = my_fam->fam_allocate(dataItem, 1024, 0444, desc));
     EXPECT_NE((void *)NULL, item);
@@ -105,7 +105,7 @@ TEST(FamMMTest, FamAllocateSameSuccess) {
     const char *dataItem = get_uniq_str("mm_data", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 4096, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 4096, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(item = my_fam->fam_allocate(dataItem, 1024, 0777, desc));
     EXPECT_NE((void *)NULL, item);
@@ -132,7 +132,7 @@ TEST(FamMMTest, FamCheckPermissionSuccess) {
     const char *dataItem = get_uniq_str("mm_data", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 4096, 0444, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 4096, 0444, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(my_fam->fam_change_permissions(desc, 0777));
 
@@ -154,17 +154,17 @@ TEST(FamMMTest, FamCreateSameRegionDestroysSuccess) {
     const char *testRegion = get_uniq_str("mm_test", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 4096, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 4096, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_THROW(desc =
-                     my_fam->fam_create_region(testRegion, 4096, 0777, RAID1),
+                     my_fam->fam_create_region(testRegion, 4096, 0777, NULL),
                  Fam_Exception);
     EXPECT_THROW(desc =
-                     my_fam->fam_create_region(testRegion, 1024, 0777, RAID1),
+                     my_fam->fam_create_region(testRegion, 1024, 0777, NULL),
                  Fam_Exception);
     EXPECT_THROW(desc =
-                     my_fam->fam_create_region(testRegion, 4096, 0444, RAID1),
+                     my_fam->fam_create_region(testRegion, 4096, 0444, NULL),
                  Fam_Exception);
 
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
@@ -180,7 +180,7 @@ TEST(FamMMTest, FamAllocateMultipleItemsSameHeapSuccess) {
     const char *testRegion = get_uniq_str("mm_test", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 2147483648, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 2147483648, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     for (int i = 0; i < num_allocs; i++) {
         string name = "test" + to_string(rand());
@@ -202,7 +202,7 @@ TEST(FamMMTest, FamAllocateUnnamedItemSuccess) {
     const char *testRegion = get_uniq_str("mm_test", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 4096, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 4096, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(item = my_fam->fam_allocate(1024, 0444, desc));
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
@@ -216,7 +216,7 @@ TEST(FamMMNegativeTest, FamCreateGreaterBignameRegionFailure) {
     const char *testRegion =
         get_uniq_str("testtesttesttesttesttesttesttesttesttest", my_fam);
 
-    EXPECT_THROW(my_fam->fam_create_region(testRegion, 4096, 0777, RAID1),
+    EXPECT_THROW(my_fam->fam_create_region(testRegion, 4096, 0777, NULL),
                  Fam_Exception);
 }
 
@@ -225,7 +225,7 @@ TEST(FamMMTest, FamCreateBignameRegionDestroySuccess) {
     const char *testRegion = get_uniq_str("memory_manager_test_region", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 4096, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 4096, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
     delete desc;
@@ -239,7 +239,7 @@ TEST(FamMMTest, FamCreateDestroyMultipleSuccess) {
 
     lookup_region(pass, my_fam, desc, name.c_str());
     if (pass == false && desc == NULL)
-        create_region(pass, my_fam, desc, name.c_str(), 4096, 0777, RAID1);
+        create_region(pass, my_fam, desc, name.c_str(), 4096, 0777, NULL);
     sleep(2);
     if (desc == NULL) {
         lookup_region(pass, my_fam, desc, name.c_str());
@@ -259,7 +259,7 @@ TEST(FamMMTest, FamCreateSameRegionDestroySuccess) {
 
     lookup_region(pass, my_fam, desc, name.c_str());
     if (pass == false && desc == NULL) {
-        create_region(pass, my_fam, desc, name.c_str(), 4096, 0777, RAID1);
+        create_region(pass, my_fam, desc, name.c_str(), 4096, 0777, NULL);
     }
     sleep(2);
     if (desc == NULL) {

--- a/test/reg-test/fam-api-reg/fam_nonfetch_arithmatic_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_nonfetch_arithmatic_atomics_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamNonfetchArithAtomicInt32, NonfetchArithAtomicInt32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -92,7 +92,7 @@ TEST(FamNonfetchArithAtomicInt64, NonfetchArithAtomicInt64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -134,7 +134,7 @@ TEST(FamNonfetchArithAtomicUint32, NonfetchArithAtomicUint32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -180,7 +180,7 @@ TEST(FamNonfetchArithAtomicUint64, NonfetchArithAtomicUint64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -226,7 +226,7 @@ TEST(FamNonfetchArithAtomicFloat, NonfetchArithAtomicFloatSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -268,7 +268,7 @@ TEST(FamNonfetchArithAtomicDouble, NonfetchArithAtomicDoubleSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_nonfetch_arithmetic_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_nonfetch_arithmetic_atomics_mt_reg_test.cpp
@@ -97,7 +97,7 @@ TEST(FamNonfetchArithAtomicInt32, NonfetchArithAtomicInt32Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -165,7 +165,7 @@ TEST(FamNonfetchArithAtomicInt64, NonfetchArithAtomicInt64Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -236,7 +236,7 @@ TEST(FamNonfetchArithAtomicUint32, NonfetchArithAtomicUint32Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -307,7 +307,7 @@ TEST(FamNonfetchArithAtomicUint64, NonfetchArithAtomicUint64Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -375,7 +375,7 @@ TEST(FamNonfetchArithAtomicFloat, NonfetchArithAtomicFloatSuccess) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -443,7 +443,7 @@ TEST(FamNonfetchArithAtomicDouble, NonfetchArithAtomicDoubleSuccess) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_nonfetch_logical_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_nonfetch_logical_atomics_mt_reg_test.cpp
@@ -106,7 +106,7 @@ TEST(FamNonfetchLogicalAtomicUint32, NonfetchLogicalAtomicUint32Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -182,7 +182,7 @@ TEST(FamNonfetchLogicalAtomicUint64, NonfetchLogicalAtomicUint64Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_nonfetch_logical_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_nonfetch_logical_atomics_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamNonfetchLogicalAtomicUint32, NonfetchLogicalAtomicUint32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -101,7 +101,7 @@ TEST(FamNonfetchLogicalAtomicUint64, NonfetchLogicalAtomicUint64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_nonfetch_min_max_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_nonfetch_min_max_atomics_mt_reg_test.cpp
@@ -96,7 +96,7 @@ TEST(FamNonfetchMinMaxAtomicInt32, NonfetchMinMaxAtomicInt32Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -163,7 +163,7 @@ TEST(FamNonfetchMinMaxAtomicInt64, NonfetchMinMaxAtomicInt64Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -231,7 +231,7 @@ TEST(FamNonfetchMinMaxAtomicUint32, NonfetchMinMaxAtomicUint32Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
     // Allocating data items in the created region
     EXPECT_NO_THROW(item = my_fam->fam_allocate(
@@ -298,7 +298,7 @@ TEST(FamNonfetchMinMaxAtomicUint64, NonfetchMinMaxAtomicUint64Success) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -366,7 +366,7 @@ TEST(FamNonfetchMinMaxAtomicFloat, NonfetchMinMaxAtomicFloatSuccess) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -434,7 +434,7 @@ TEST(FamNonfetchMinMaxAtomicDouble, NonfetchMinMaxAtomicDoubleSuccess) {
     info = (ValueInfo *)malloc(sizeof(ValueInfo) * NUM_THREADS);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, REGION_SIZE, 0777, RAID1));
+                        testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_nonfetch_min_max_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_nonfetch_min_max_atomics_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamNonfetchMinMaxAtomicInt32, NonfetchMinMaxAtomicInt32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -90,7 +90,7 @@ TEST(FamNonfetchMinMaxAtomicInt64, NonfetchMinMaxAtomicInt64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -129,7 +129,7 @@ TEST(FamNonfetchMinMaxAtomicUint32, NonfetchMinMaxAtomicUint32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -168,7 +168,7 @@ TEST(FamNonfetchMinMaxAtomicUint64, NonfetchMinMaxAtomicUint64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -207,7 +207,7 @@ TEST(FamNonfetchMinMaxAtomicFloat, NonfetchMinMaxAtomicFloatSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -246,7 +246,7 @@ TEST(FamNonfetchMinMaxAtomicDouble, NonfetchMinMaxAtomicDoubleSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_noperm_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_noperm_reg_test.cpp
@@ -52,7 +52,7 @@ TEST(FamNoPerm, NoPermSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_put_get_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_get_mt_reg_test.cpp
@@ -174,13 +174,13 @@ TEST(FamPutGetMT, BlockingPutGetMTMultipleRegionDataItem) {
     const char *region3 = get_uniq_str("test113", my_fam);
 
     EXPECT_NO_THROW(desc1 = my_fam->fam_create_region(
-                        region1, (8192 * NUM_THREADS), 0777, RAID1));
+                        region1, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, desc1);
     EXPECT_NO_THROW(desc2 = my_fam->fam_create_region(
-                        region2, (8192 * NUM_THREADS), 0777, RAID1));
+                        region2, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, desc2);
     EXPECT_NO_THROW(desc3 = my_fam->fam_create_region(
-                        region3, (8192 * NUM_THREADS), 0777, RAID1));
+                        region3, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, desc3);
 
     // Allocating data items in the created region
@@ -591,7 +591,7 @@ int main(int argc, char **argv) {
     EXPECT_NO_THROW(my_fam->fam_initialize("default", &fam_opts));
     testRegionStr = get_uniq_str("test", my_fam);
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_put_get_nb_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_get_nb_mt_reg_test.cpp
@@ -183,13 +183,13 @@ TEST(FamPutGetMT, NonblockingPutGetMTMultipleRegionDataItem) {
     const char *region3 = get_uniq_str("test113", my_fam);
 
     EXPECT_NO_THROW(desc1 = my_fam->fam_create_region(
-                        region1, (8192 * NUM_THREADS), 0777, RAID1));
+                        region1, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, desc1);
     EXPECT_NO_THROW(desc2 = my_fam->fam_create_region(
-                        region2, (8192 * NUM_THREADS), 0777, RAID1));
+                        region2, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, desc2);
     EXPECT_NO_THROW(desc3 = my_fam->fam_create_region(
-                        region3, (8192 * NUM_THREADS), 0777, RAID1));
+                        region3, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, desc3);
 
     //    item = (Fam_Descriptor *)malloc(sizeof(Fam_Descriptor) * 3);
@@ -419,7 +419,7 @@ int main(int argc, char **argv) {
     EXPECT_NO_THROW(my_fam->fam_initialize("default", &fam_opts));
     testRegionStr = get_uniq_str("test", my_fam);
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_put_get_negative_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_get_negative_test.cpp
@@ -52,7 +52,7 @@ TEST(FamPutGetT, PutGetFail) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -140,7 +140,7 @@ TEST(FamPutGetT, ScatterGatherIndexFail) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -245,7 +245,7 @@ TEST(FamPutGetT, ScatterGatherStrideFail) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_put_get_quiet_nonblock_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_get_quiet_nonblock_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamPutGetNonblock, PutGetNonblockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_put_get_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_get_reg_test.cpp
@@ -52,7 +52,7 @@ TEST(FamPutGet, PutGetSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_put_get_region_ctx_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_get_region_ctx_reg_test.cpp
@@ -52,7 +52,7 @@ TEST(FamPutGetRegionCtx, PutGetRegionCtxSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_put_get_user_desc_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_get_user_desc_reg_test.cpp
@@ -52,7 +52,7 @@ TEST(FamPutGet, PutGetSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_put_getblocking_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_put_getblocking_reg_test.cpp
@@ -52,7 +52,7 @@ TEST(FamPutGet, PutGetSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_scatter_gather_blocking_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_scatter_gather_blocking_mt_reg_test.cpp
@@ -149,7 +149,7 @@ TEST(FamScatterGatherIndexBlockMT, ScatterGatherIndexBlockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, (8192 * NUM_THREADS), 0777, RAID1));
+                        testRegion, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -189,7 +189,7 @@ TEST(FamScatterGatherStrideBlockMT, ScatterGatherStrideBlockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, (8192 * NUM_THREADS), 0777, RAID1));
+                        testRegion, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -229,7 +229,7 @@ TEST(FamScatterGatherIndexBlockMT, ScatterGatherIndexBlockFailure) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, (8192 * NUM_THREADS), 0777, RAID1));
+                        testRegion, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region
@@ -271,7 +271,7 @@ TEST(FamScatterGatherStrideBlockMT, ScatterGatherStrideBlockFailure) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, (8192 * NUM_THREADS), 0777, RAID1));
+                        testRegion, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_scatter_gather_index_blocking_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_scatter_gather_index_blocking_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamScatterGatherIndexBlock, ScatterGatherIndexBlockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_scatter_gather_index_nonblocking_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_scatter_gather_index_nonblocking_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamScatterGatherIndexNonblock, ScatterGatherIndexNonblockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_scatter_gather_index_user_desc_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_scatter_gather_index_user_desc_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamScatterGatherIndexBlock, ScatterGatherIndexBlockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_scatter_gather_nonblocking_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_scatter_gather_nonblocking_mt_reg_test.cpp
@@ -110,7 +110,7 @@ TEST(FamScatterGatherIndexNonblockMT, ScatterGatherIndexNonblockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, (8192 * NUM_THREADS), 0777, RAID1));
+                        testRegion, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
     // Allocating data items in the created region
     EXPECT_NO_THROW(item = my_fam->fam_allocate(firstItem, (1024 * NUM_THREADS),
@@ -151,7 +151,7 @@ TEST(FamScatterGatherStrideNonblockMT, ScatterGatherStrideNonblockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegion, (8192 * NUM_THREADS), 0777, RAID1));
+                        testRegion, (8192 * NUM_THREADS), 0777, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_scatter_gather_stride_blocking_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_scatter_gather_stride_blocking_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamScatterGatherStrideBlock, ScatterGatherStrideBlockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_scatter_gather_stride_nonblocking_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_scatter_gather_stride_nonblocking_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamScatterGatherStrideNonblock, ScatterGatherStrideNonblockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_scatter_gather_stride_user_desc_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_scatter_gather_stride_user_desc_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamScatterGatherStrideBlock, ScatterGatherStrideBlockSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_shm_tests.cpp
+++ b/test/reg-test/fam-api-reg/fam_shm_tests.cpp
@@ -67,7 +67,7 @@ TEST(FamShmTests, PutGetSuccess) {
 
     if (*myPE == 0) {
         EXPECT_NO_THROW(
-            desc = my_fam->fam_create_region("test", 8192, 0777, RAID1));
+            desc = my_fam->fam_create_region("test", 8192, 0777, NULL));
         EXPECT_NE((void *)NULL, desc);
     }
 
@@ -130,7 +130,7 @@ TEST(FamShmTests, ChangePermSuccess) {
 
     if (*myPE == 0) {
         EXPECT_NO_THROW(
-            desc = my_fam->fam_create_region("test", 8192, 0777, RAID1));
+            desc = my_fam->fam_create_region("test", 8192, 0777, NULL));
         EXPECT_NE((void *)NULL, desc);
     }
 
@@ -189,7 +189,7 @@ TEST(FamShmTests, UserDescriptorSuccess) {
 
     if (*myPE == 0) {
         EXPECT_NO_THROW(
-            desc = my_fam->fam_create_region("test", 8192, 0777, RAID1));
+            desc = my_fam->fam_create_region("test", 8192, 0777, NULL));
         EXPECT_NE((void *)NULL, desc);
     }
 

--- a/test/reg-test/fam-api-reg/fam_stat_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_stat_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamStat, FamStatSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(my_fam->fam_stat(desc, info));
     cout << "Region Info  - Name : " << info->name << " Size: " << std::dec
@@ -83,7 +83,7 @@ TEST(FamStat, FamStatSuccessUnnamedDataItem) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(my_fam->fam_stat(desc, info));
     cout << "Region Info  - Name : " << info->name << " Size: " << std::dec
@@ -117,7 +117,7 @@ TEST(FamStat, FamStatSuccessCompareSize) {
     uint64_t size, sizeCopy;
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_NO_THROW(descCopy = my_fam->fam_lookup_region(testRegion));
@@ -164,7 +164,7 @@ TEST(FamStat, FamStatLookup) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -200,7 +200,7 @@ TEST(FamStat, FamStatGlobalDescriptor) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -245,7 +245,7 @@ TEST(FamStat, FamStatFailure) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -306,7 +306,7 @@ TEST(FamStat, FamStatAll) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_stat_reg_test_shm.cpp
+++ b/test/reg-test/fam-api-reg/fam_stat_reg_test_shm.cpp
@@ -51,7 +51,7 @@ TEST(FamStat, FamStatSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(my_fam->fam_stat(desc, info));
     cout << "Region Info  - Name : " << info->name << " Size: " << std::dec
@@ -83,7 +83,7 @@ TEST(FamStat, FamStatSuccessUnnamedDataItem) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
     EXPECT_NO_THROW(my_fam->fam_stat(desc, info));
     cout << "Region Info  - Name : " << info->name << " Size: " << std::dec
@@ -117,7 +117,7 @@ TEST(FamStat, FamStatSuccessCompareSize) {
     uint64_t size, sizeCopy;
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_NO_THROW(descCopy = my_fam->fam_lookup_region(testRegion));
@@ -164,7 +164,7 @@ TEST(FamStat, FamStatLookup) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -200,7 +200,7 @@ TEST(FamStat, FamStatGlobalDescriptor) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -245,7 +245,7 @@ TEST(FamStat, FamStatFailure) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -306,7 +306,7 @@ TEST(FamStat, FamStatAll) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/fam-api-reg/fam_swap_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_swap_atomics_mt_reg_test.cpp
@@ -384,7 +384,7 @@ int main(int argc, char **argv) {
     testRegionStr = get_uniq_str("test", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_swap_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_swap_atomics_reg_test.cpp
@@ -356,7 +356,7 @@ int main(int argc, char **argv) {
     testRegionStr = get_uniq_str("test", my_fam);
 
     EXPECT_NO_THROW(testRegionDesc = my_fam->fam_create_region(
-                        testRegionStr, REGION_SIZE, REGION_PERM, RAID1));
+                        testRegionStr, REGION_SIZE, REGION_PERM, NULL));
     EXPECT_NE((void *)NULL, testRegionDesc);
 
     ret = RUN_ALL_TESTS();

--- a/test/reg-test/fam-api-reg/fam_swap_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_swap_reg_test.cpp
@@ -51,7 +51,7 @@ TEST(FamSwapInt32, SwapInt32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -84,7 +84,7 @@ TEST(FamSwapInt64, SwapInt64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -117,7 +117,7 @@ TEST(FamSwapUint32, SwapUint32Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -150,7 +150,7 @@ TEST(FamSwapUint64, SwapUint64Success) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -183,7 +183,7 @@ TEST(FamSwapFloat, SwapFloatSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region
@@ -216,7 +216,7 @@ TEST(FamSwapDouble, SwapDoubleSuccess) {
     const char *firstItem = get_uniq_str("first", my_fam);
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, 8192, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, 8192, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     // Allocating data items in the created region

--- a/test/reg-test/metadata-reg/fam_metadata_reg_test.cpp
+++ b/test/reg-test/metadata-reg/fam_metadata_reg_test.cpp
@@ -70,7 +70,7 @@ TEST(FamMetadata, RegionSuccess) {
     memset(regnode, 0, sizeof(Fam_Region_Metadata));
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_EQ(META_NO_ERROR, manager->metadata_find_region(testRegion, node));
@@ -147,13 +147,13 @@ TEST(FamMetadata, RegionFail) {
     memset(regnode, 0, sizeof(Fam_Region_Metadata));
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_EQ(META_NO_ERROR, manager->metadata_find_region(testRegion, node));
 
     EXPECT_THROW(
-        my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1),
+        my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL),
         Fam_Exception);
 
     regionId = node.regionId;
@@ -219,7 +219,7 @@ TEST(FamMetadata, DataitemSuccess) {
     memset(datanode, 0, sizeof(Fam_DataItem_Metadata));
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_EQ(META_NO_ERROR, manager->metadata_find_region(testRegion, node));
@@ -315,7 +315,7 @@ TEST(FamMetadata, DataitemFail) {
     memset(datanode, 0, sizeof(Fam_DataItem_Metadata));
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_EQ(META_NO_ERROR, manager->metadata_find_region(testRegion, node));

--- a/test/unit-test/allocator/fam_allocator_test.cpp
+++ b/test/unit-test/allocator/fam_allocator_test.cpp
@@ -60,7 +60,7 @@ int main() {
 
     // Create Region
     bool pass = true;
-    create_region(pass, my_fam, desc, "test", 8192, 0444, RAID1);
+    create_region(pass, my_fam, desc, "test", 8192, 0444, NULL);
     if (!pass) {
         if (desc != NULL)
             destroy_region(pass, my_fam, desc);

--- a/test/unit-test/allocator/fam_allocator_test_nvmm.cpp
+++ b/test/unit-test/allocator/fam_allocator_test_nvmm.cpp
@@ -83,7 +83,7 @@ int main() {
     }
 
     // Create Region
-    desc = my_fam->fam_create_region("test", 8192, 0444, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0444, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/allocator/fam_invalidkey_test.cpp
+++ b/test/unit-test/allocator/fam_invalidkey_test.cpp
@@ -78,7 +78,7 @@ int main() {
     }
 
     // Create Region
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_allocate_map_nvmm.cpp
+++ b/test/unit-test/fam-api/fam_allocate_map_nvmm.cpp
@@ -66,7 +66,7 @@ int main() {
     }
 
     try {
-        desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+        desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;

--- a/test/unit-test/fam-api/fam_compare_swap_atomics_128_mt.cpp
+++ b/test/unit-test/fam-api/fam_compare_swap_atomics_128_mt.cpp
@@ -110,7 +110,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_compare_swap_atomics_nvmm_test.cpp
+++ b/test/unit-test/fam-api/fam_compare_swap_atomics_nvmm_test.cpp
@@ -79,7 +79,7 @@ int main() {
         return TEST_SKIP_STATUS;
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_compare_swap_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_compare_swap_atomics_test.cpp
@@ -67,7 +67,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_copy_test.cpp
+++ b/test/unit-test/fam-api/fam_copy_test.cpp
@@ -58,7 +58,7 @@ int main() {
         exit(1);
     }
 
-    srcDesc = my_fam->fam_create_region("srcRegion", 8192, 0777, RAID1);
+    srcDesc = my_fam->fam_create_region("srcRegion", 8192, 0777, NULL);
     if (srcDesc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
@@ -70,7 +70,7 @@ int main() {
         exit(1);
     }
 
-    destDesc = my_fam->fam_create_region("destRegion", 8192, 0777, RAID1);
+    destDesc = my_fam->fam_create_region("destRegion", 8192, 0777, NULL);
     if (destDesc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_create_alloc_destroy_mt.cpp
+++ b/test/unit-test/fam-api/fam_create_alloc_destroy_mt.cpp
@@ -137,21 +137,21 @@ int main() {
     }
 
     try {
-        desc1 = my_fam->fam_create_region("test111", 8192, 0777, RAID1);
+        desc1 = my_fam->fam_create_region("test111", 8192, 0777, NULL);
     } catch (Fam_Exception &e) {
         cout << "fam create region failed: " << e.fam_error_msg() << endl;
         exit(1);
     }
 
     try {
-        desc2 = my_fam->fam_create_region("test112", 8192, 0777, RAID1);
+        desc2 = my_fam->fam_create_region("test112", 8192, 0777, NULL);
     } catch (Fam_Exception &e) {
         cout << "fam create region failed: " << e.fam_error_msg() << endl;
         exit(1);
     }
 
     try {
-        desc3 = my_fam->fam_create_region("test113", 8192, 0777, RAID1);
+        desc3 = my_fam->fam_create_region("test113", 8192, 0777, NULL);
     } catch (Fam_Exception &e) {
         cout << "fam create region failed: " << e.fam_error_msg() << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_create_destroy_region_test.cpp
+++ b/test/unit-test/fam-api/fam_create_destroy_region_test.cpp
@@ -57,7 +57,7 @@ int main() {
     int i = 0;
 
     for (i = 0; i < 10; i++) {
-        desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+        desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
         if (desc == NULL) {
             cout << "fam create region failed" << endl;
             exit(1);
@@ -80,31 +80,31 @@ int main() {
 
     Fam_Region_Descriptor *desc1, *desc2, *desc3, *desc4, *desc5;
 
-    desc1 = my_fam->fam_create_region("test1", 8192, 0777, RAID1);
+    desc1 = my_fam->fam_create_region("test1", 8192, 0777, NULL);
     if (desc1 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
     }
 
-    desc2 = my_fam->fam_create_region("test2", 8192, 0777, RAID1);
+    desc2 = my_fam->fam_create_region("test2", 8192, 0777, NULL);
     if (desc2 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
     }
 
-    desc3 = my_fam->fam_create_region("test3", 8192, 0777, RAID1);
+    desc3 = my_fam->fam_create_region("test3", 8192, 0777, NULL);
     if (desc3 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
     }
 
-    desc4 = my_fam->fam_create_region("test4", 8192, 0777, RAID1);
+    desc4 = my_fam->fam_create_region("test4", 8192, 0777, NULL);
     if (desc4 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
     }
 
-    desc5 = my_fam->fam_create_region("test5", 8192, 0777, RAID1);
+    desc5 = my_fam->fam_create_region("test5", 8192, 0777, NULL);
     if (desc5 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
@@ -116,13 +116,13 @@ int main() {
     if (desc2 != NULL)
         my_fam->fam_destroy_region(desc2);
 
-    desc1 = my_fam->fam_create_region("test1", 8192, 0777, RAID1);
+    desc1 = my_fam->fam_create_region("test1", 8192, 0777, NULL);
     if (desc1 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
     }
 
-    desc2 = my_fam->fam_create_region("test2", 8192, 0777, RAID1);
+    desc2 = my_fam->fam_create_region("test2", 8192, 0777, NULL);
     if (desc2 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
@@ -143,13 +143,13 @@ int main() {
     if (desc5 != NULL)
         my_fam->fam_destroy_region(desc5);
 
-    desc4 = my_fam->fam_create_region("test4", 8192, 0777, RAID1);
+    desc4 = my_fam->fam_create_region("test4", 8192, 0777, NULL);
     if (desc4 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
     }
 
-    desc5 = my_fam->fam_create_region("test5", 8192, 0777, RAID1);
+    desc5 = my_fam->fam_create_region("test5", 8192, 0777, NULL);
     if (desc5 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_create_destroy_region_test_mt.cpp
+++ b/test/unit-test/fam-api/fam_create_destroy_region_test_mt.cpp
@@ -50,21 +50,21 @@ void *thr_func(void *arg) {
 
     string name;
     name = "test" + to_string(rand());
-    desc1 = my_fam->fam_create_region(name.c_str(), 8192, 0777, RAID1);
+    desc1 = my_fam->fam_create_region(name.c_str(), 8192, 0777, NULL);
     if (desc1 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
     }
 
     name = "test" + to_string(rand());
-    desc2 = my_fam->fam_create_region(name.c_str(), 8192, 0777, RAID1);
+    desc2 = my_fam->fam_create_region(name.c_str(), 8192, 0777, NULL);
     if (desc2 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
     }
 
     name = "test" + to_string(rand());
-    desc3 = my_fam->fam_create_region(name.c_str(), 8192, 0777, RAID1);
+    desc3 = my_fam->fam_create_region(name.c_str(), 8192, 0777, NULL);
     if (desc3 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
@@ -80,14 +80,14 @@ void *thr_func(void *arg) {
         my_fam->fam_destroy_region(desc2);
 
     name = "test" + to_string(rand());
-    desc1 = my_fam->fam_create_region(name.c_str(), 8192, 0777, RAID1);
+    desc1 = my_fam->fam_create_region(name.c_str(), 8192, 0777, NULL);
     if (desc1 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
     }
 
     name = "test" + to_string(rand());
-    desc2 = my_fam->fam_create_region(name.c_str(), 8192, 0777, RAID1);
+    desc2 = my_fam->fam_create_region(name.c_str(), 8192, 0777, NULL);
     if (desc2 == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_fence_test.cpp
+++ b/test/unit-test/fam-api/fam_fence_test.cpp
@@ -67,7 +67,7 @@ int main() {
 
     Fam_Region_Descriptor *desc;
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_fetch_arithmatic_atomics_nvmm_test.cpp
+++ b/test/unit-test/fam-api/fam_fetch_arithmatic_atomics_nvmm_test.cpp
@@ -79,7 +79,7 @@ int main() {
         return TEST_SKIP_STATUS;
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_fetch_arithmatic_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_fetch_arithmatic_atomics_test.cpp
@@ -67,7 +67,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_fetch_logical_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_fetch_logical_atomics_test.cpp
@@ -67,7 +67,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_fetch_min_max_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_fetch_min_max_atomics_test.cpp
@@ -67,7 +67,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_invalid_key_test.cpp
+++ b/test/unit-test/fam-api/fam_invalid_key_test.cpp
@@ -102,7 +102,7 @@ int main() {
     }
 
     // Create Region
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_invalid_offset_test.cpp
+++ b/test/unit-test/fam-api/fam_invalid_offset_test.cpp
@@ -56,7 +56,7 @@ int main() {
     }
 
     try {
-        desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+        desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;

--- a/test/unit-test/fam-api/fam_nonfetch_arithmatic_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_nonfetch_arithmatic_atomics_test.cpp
@@ -69,7 +69,7 @@ int main() {
     }
 
     try {
-        desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+        desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;

--- a/test/unit-test/fam-api/fam_nonfetch_logical_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_nonfetch_logical_atomics_test.cpp
@@ -67,7 +67,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_nonfetch_min_max_atomics_test.cpp
+++ b/test/unit-test/fam-api/fam_nonfetch_min_max_atomics_test.cpp
@@ -67,7 +67,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_noperm_test.cpp
+++ b/test/unit-test/fam-api/fam_noperm_test.cpp
@@ -54,7 +54,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test1", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test1", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);
@@ -92,7 +92,7 @@ int main() {
         my_fam->fam_destroy_region(desc);
 
     // Create region with read-only perm
-    desc = my_fam->fam_create_region("test1", 8192, 0444, RAID1);
+    desc = my_fam->fam_create_region("test1", 8192, 0444, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_progress.cpp
+++ b/test/unit-test/fam-api/fam_progress.cpp
@@ -55,7 +55,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_put_get.cpp
+++ b/test/unit-test/fam-api/fam_put_get.cpp
@@ -53,7 +53,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_put_get_multiple.cpp
+++ b/test/unit-test/fam-api/fam_put_get_multiple.cpp
@@ -55,7 +55,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_put_get_region_ctx.cpp
+++ b/test/unit-test/fam-api/fam_put_get_region_ctx.cpp
@@ -57,7 +57,7 @@ int main() {
     }
 
     try {
-        desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+        desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;

--- a/test/unit-test/fam-api/fam_put_get_user_desc.cpp
+++ b/test/unit-test/fam-api/fam_put_get_user_desc.cpp
@@ -53,7 +53,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_quiet_put_get_nonblocking.cpp
+++ b/test/unit-test/fam-api/fam_quiet_put_get_nonblocking.cpp
@@ -53,7 +53,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_scatter_gather_index_blocking.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_index_blocking.cpp
@@ -56,7 +56,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_scatter_gather_index_nonblocking.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_index_nonblocking.cpp
@@ -56,7 +56,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_scatter_gather_index_user_desc.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_index_user_desc.cpp
@@ -57,7 +57,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_blocking.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_blocking.cpp
@@ -56,7 +56,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_blocking_with_validation.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_blocking_with_validation.cpp
@@ -58,7 +58,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("sg_test", 1048576, 0777, RAID1);
+    desc = my_fam->fam_create_region("sg_test", 1048576, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_nonblocking.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_nonblocking.cpp
@@ -56,7 +56,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_nonblocking_with_validation.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_nonblocking_with_validation.cpp
@@ -58,7 +58,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("sg_test", 1048576, 0777, RAID1);
+    desc = my_fam->fam_create_region("sg_test", 1048576, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_scatter_gather_stride_user_desc.cpp
+++ b/test/unit-test/fam-api/fam_scatter_gather_stride_user_desc.cpp
@@ -56,7 +56,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/fam-api/fam_swap_test.cpp
+++ b/test/unit-test/fam-api/fam_swap_test.cpp
@@ -67,7 +67,7 @@ int main() {
         exit(1);
     }
 
-    desc = my_fam->fam_create_region("test", 8192, 0777, RAID1);
+    desc = my_fam->fam_create_region("test", 8192, 0777, NULL);
     if (desc == NULL) {
         cout << "fam create region failed" << endl;
         exit(1);

--- a/test/unit-test/metadata/fam_metadata_regress_test.cpp
+++ b/test/unit-test/metadata/fam_metadata_regress_test.cpp
@@ -70,7 +70,7 @@ TEST(FamMetadata, RegionSuccess) {
     memset(regnode, 0, sizeof(Fam_Region_Metadata));
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_EQ(true, manager->metadata_find_region(testRegion, node));
@@ -141,13 +141,13 @@ TEST(FamMetadata, RegionFail) {
     memset(regnode, 0, sizeof(Fam_Region_Metadata));
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_NO_THROW(manager->metadata_find_region(testRegion, node));
 
     EXPECT_THROW(
-        my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1),
+        my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL),
         Fam_Exception);
 
     regionId = node.regionId;
@@ -214,7 +214,7 @@ TEST(FamMetadata, DataitemSuccess) {
     memset(datanode, 0, sizeof(Fam_DataItem_Metadata));
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_EQ(true, manager->metadata_find_region(testRegion, node));
@@ -307,7 +307,7 @@ TEST(FamMetadata, DataitemFail) {
     memset(datanode, 0, sizeof(Fam_DataItem_Metadata));
 
     EXPECT_NO_THROW(
-        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, RAID1));
+        desc = my_fam->fam_create_region(testRegion, REGION_SIZE, 0777, NULL));
     EXPECT_NE((void *)NULL, desc);
 
     EXPECT_EQ(true, manager->metadata_find_region(testRegion, node));

--- a/test/unit-test/metadata/fam_metadata_rpc_test.cpp
+++ b/test/unit-test/metadata/fam_metadata_rpc_test.cpp
@@ -163,7 +163,7 @@ int main(int argc, char *argv[]) {
         uint64_t regionId;
 
         desc[i] = my_fam->fam_create_region(to_string(i).c_str(),
-                                            16 * 1024 * 1024, 0744, RAID1);
+                                            16 * 1024 * 1024, 0744, NULL);
         if (desc[i] == NULL) {
             cout << "fam create region failed" << endl;
             exit(1);

--- a/test/unit-test/metadata/fam_metadata_test.cpp
+++ b/test/unit-test/metadata/fam_metadata_test.cpp
@@ -93,7 +93,7 @@ int main(int argc, char *argv[]) {
         uint64_t regionId;
 
         desc[i] = my_fam->fam_create_region(to_string(i).c_str(),
-                                            16 * 1024 * 1024, 0744, RAID1);
+                                            16 * 1024 * 1024, 0744, NULL);
         if (desc[i] == NULL) {
             cout << "fam create region failed" << endl;
             exit(1);

--- a/test/util/fam_utils.h
+++ b/test/util/fam_utils.h
@@ -40,7 +40,7 @@ using namespace chrono;
                       attributes)                                              \
     try {                                                                      \
         region =                                                               \
-            my_fam->fam_create_region(name, size, permission, NULL);     \
+            my_fam->fam_create_region(name, size, permission, attributes);     \
     } catch (Fam_Exception & e) {                                              \
         pass = false;                                                          \
         cout << "Exception caught" << endl;                                    \

--- a/test/util/fam_utils.h
+++ b/test/util/fam_utils.h
@@ -37,10 +37,10 @@ using namespace std;
 using namespace chrono;
 
 #define create_region(pass, my_fam, region, name, size, permission,            \
-                      redundancy)                                              \
+                      attributes)                                              \
     try {                                                                      \
         region =                                                               \
-            my_fam->fam_create_region(name, size, permission, redundancy);     \
+            my_fam->fam_create_region(name, size, permission, NULL);     \
     } catch (Fam_Exception & e) {                                              \
         pass = false;                                                          \
         cout << "Exception caught" << endl;                                    \


### PR DESCRIPTION
Changed the fam_create_region attribute parameter to take NULL in all references of this API in test files.