### PR TITLE
Fixed #105 : CIS:Return error for duplicate memserver id

### DIFF
--- a/src/cis/fam_cis_direct.cpp
+++ b/src/cis/fam_cis_direct.cpp
@@ -150,8 +150,14 @@ Fam_CIS_Direct::Fam_CIS_Direct(char *cisName, bool useAsyncCopy_,
             std::pair<std::string, uint64_t> service = obj->second;
             Fam_Memory_Service *memoryService = new Fam_Memory_Service_Client(
                 (service.first).c_str(), service.second);
-            memoryServers->insert({ obj->first, memoryService });
+            if (memoryServers->find(obj->first) != memoryServers->end()) {
+                message << "CIS:Duplicate memory server id! ";
+                std::cout << message << std::endl;
+                THROW_ERR_MSG(Fam_InvalidOption_Exception,
+                              message.str().c_str());
+            }
 
+            memoryServers->insert({obj->first, memoryService});
             size_t addrSize = get_addr_size(obj->first);
             Fam_Memory_Type memory_type = memoryService->get_memtype();
             if (memory_type == PERSISTENT) {

--- a/test/reg-test/fam-api-reg/fam_min_max_atomics_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_min_max_atomics_mt_reg_test.cpp
@@ -61,8 +61,9 @@ int rc;
 #define NUM_THREADS 10
 #define REGION_SIZE (32 * 1024 * NUM_THREADS)
 #define REGION_PERM 0777
-
+#ifdef ENABLE_KNOWN_ISSUES
 #define SHM_CHECK (strcmp(openFamModel, "shared_memory") == 0)
+#endif
 
 typedef struct {
     Fam_Descriptor *item;
@@ -797,7 +798,7 @@ TEST(FamMinMaxAtomics, MinMaxDoubleBlock) {
     delete item;
     free((void *)dataItem);
 }
-#if 0
+#ifdef ENABLE_KNOWN_ISSUES
 // Test case 13 - Min Max Negative test case with invalid permissions
 void *thrd_min_max_inv_perms(void *arg) {
 


### PR DESCRIPTION
Fixing https://github.com/OpenFAM/OpenFAM/issues/105 (Return error if duplicate memory server id is provided during CIS started up)