### PR TITLE
Fam progress fix for multiple contexts

### DIFF
--- a/src/fam-api/fam_ops_libfabric.cpp
+++ b/src/fam-api/fam_ops_libfabric.cpp
@@ -669,9 +669,7 @@ void Fam_Ops_Libfabric::quiet(Fam_Region_Descriptor *descriptor) {
 
 uint64_t Fam_Ops_Libfabric::progress_context() {
     uint64_t pending = 0;
-    for (auto fam_ctx : *defContexts) {
-        pending += fabric_progress(fam_ctx.second);
-    }
+    pending = fabric_progress(get_defaultCtx(get_context_id()));
     return pending;
 }
 

--- a/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
@@ -54,7 +54,9 @@ int rc;
 #define REGION_PERM 0777
 #define NUM_ITERATIONS 100
 #define NUM_IO_ITERATIONS 5
-#define NUM_CONTEXTS 7
+#define NUM_CONTEXTS                                                           \
+    7 // to increase the number of contexts, we need to increase the number of
+      // open files
 typedef struct {
     Fam_Descriptor *item;
     uint64_t offset;

--- a/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
@@ -54,9 +54,11 @@ int rc;
 #define REGION_PERM 0777
 #define NUM_ITERATIONS 100
 #define NUM_IO_ITERATIONS 5
-#define NUM_CONTEXTS                                                           \
-    7 // to increase the number of contexts, we need to increase the number of
-      // open files
+
+// to increase the number of contexts, we need to increase the number of open
+// files
+#define NUM_CONTEXTS 7
+
 typedef struct {
     Fam_Descriptor *item;
     uint64_t offset;

--- a/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
@@ -55,8 +55,8 @@ int rc;
 #define NUM_ITERATIONS 100
 #define NUM_IO_ITERATIONS 5
 
-// to increase the number of contexts, we need to increase the number of open
-// files
+// To increase the number of contexts, we need to increase open
+// files limit for the process
 #define NUM_CONTEXTS 7
 
 typedef struct {

--- a/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
@@ -55,8 +55,8 @@ int rc;
 #define NUM_ITERATIONS 100
 #define NUM_IO_ITERATIONS 5
 
-// To increase the number of contexts, we need to increase open
-// files limit for the process
+// To increase the number of contexts, we need to increase
+// the open files limit for the process
 #define NUM_CONTEXTS 7
 
 typedef struct {

--- a/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_context_mt_reg_test.cpp
@@ -49,12 +49,12 @@ Fam_Options fam_opts;
 Fam_Region_Descriptor *testRegionDesc;
 const char *testRegionStr;
 int rc;
-#define NUM_THREADS 10
+#define NUM_THREADS 7
 #define REGION_SIZE (32 * 1024 * NUM_THREADS)
 #define REGION_PERM 0777
 #define NUM_ITERATIONS 100
 #define NUM_IO_ITERATIONS 5
-#define NUM_CONTEXTS 256
+#define NUM_CONTEXTS 7
 typedef struct {
     Fam_Descriptor *item;
     uint64_t offset;

--- a/test/reg-test/fam-api-reg/fam_context_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_context_reg_test.cpp
@@ -49,7 +49,7 @@ Fam_Region_Descriptor *testRegionDesc;
 const char *testRegionStr;
 #define NUM_ITERATIONS 100
 #define NUM_IO_ITERATIONS 5
-#define NUM_CONTEXTS 256
+#define NUM_CONTEXTS 50
 typedef struct {
     Fam_Descriptor *item;
     uint64_t offset;

--- a/test/reg-test/fam-api-reg/fam_context_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_context_reg_test.cpp
@@ -49,7 +49,11 @@ Fam_Region_Descriptor *testRegionDesc;
 const char *testRegionStr;
 #define NUM_ITERATIONS 100
 #define NUM_IO_ITERATIONS 5
+
+// To increase the number of contexts, we need to increase
+// the open files limit for the process
 #define NUM_CONTEXTS 50
+
 typedef struct {
     Fam_Descriptor *item;
     uint64_t offset;


### PR DESCRIPTION
1. Fixed an issue in fam_progress
2. Modified test programs to limit the number of active contexts to 50 in both multithreaded and single threaded regression tests for fam_context model