### PR TITLE
Added negative test case for fam_context model with control path APIs

### DIFF
--- a/src/fam-api/fam.cpp
+++ b/src/fam-api/fam.cpp
@@ -5757,13 +5757,13 @@ void fam_context::fam_change_permissions(Fam_Descriptor *descriptor,
         "fam_change_permission cannot be invoked from fam_context object");
 }
 
-fam_context *fam_context_open() {
+fam_context *fam_context::fam_context_open() {
     THROW_ERRNO_MSG(
         Fam_Exception, FAM_ERR_NOPERM,
         "fam_context_open cannot be invoked from fam_context object");
 }
 
-void fam_context_close(fam_context *) {
+void fam_context::fam_context_close(fam_context *) {
     THROW_ERRNO_MSG(
         Fam_Exception, FAM_ERR_NOPERM,
         "fam_context_close cannot be invoked from fam_context object");

--- a/test/reg-test/fam-api-reg/fam_context_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_context_reg_test.cpp
@@ -142,6 +142,33 @@ TEST(FamContext, FamContextSimultaneousOpenCloseStressTest) {
     }
 }
 
+// Test case 5- FamContextNegativeTest
+TEST(FamContextModel, FamContextNegativeTest) {
+    fam_context *ctx;
+    Fam_Descriptor *item;
+    EXPECT_NO_THROW(ctx = my_fam->fam_context_open());
+    EXPECT_THROW(ctx->fam_initialize("myApplication", &fam_opts),
+                 Fam_Exception);
+    EXPECT_THROW(ctx->fam_finalize("myApplication"), Fam_Exception);
+    EXPECT_THROW(ctx->fam_abort(-1), Fam_Exception);
+    EXPECT_THROW(ctx->fam_barrier_all(), Fam_Exception);
+    EXPECT_THROW(ctx->fam_list_options(), Fam_Exception);
+    EXPECT_THROW(ctx->fam_get_option(strdup("PE_ID")), Fam_Exception);
+    EXPECT_THROW(ctx->fam_lookup_region("myRegion"), Fam_Exception);
+    EXPECT_THROW(ctx->fam_lookup("myItem", ("myRegion")), Fam_Exception);
+    EXPECT_THROW(ctx->fam_create_region("myRegion", (uint64_t)1000, 0777, NULL),
+                 Fam_Exception);
+    EXPECT_THROW(ctx->fam_destroy_region(testRegionDesc), Fam_Exception);
+    EXPECT_THROW(ctx->fam_resize_region(testRegionDesc, 1024), Fam_Exception);
+    EXPECT_THROW(ctx->fam_allocate(1024, 0444, testRegionDesc), Fam_Exception);
+    EXPECT_THROW(ctx->fam_allocate("myItem", 1024, 0444, testRegionDesc),
+                 Fam_Exception);
+    EXPECT_THROW(ctx->fam_deallocate(item), Fam_Exception);
+    EXPECT_THROW(ctx->fam_change_permissions(item, 0777), Fam_Exception);
+    EXPECT_THROW(ctx->fam_context_open(), Fam_Exception);
+    EXPECT_THROW(ctx->fam_context_close(ctx), Fam_Exception);
+    EXPECT_NO_THROW(my_fam->fam_context_close(ctx));
+}
 int main(int argc, char **argv) {
     int ret = 0;
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Added negative test case for fam_context model with control path APIs
Also fixed an issue in fam.cpp