### PR TITLE
Interleaving and registration related bug fixes

### DIFF
--- a/include/fam/fam_exception.h
+++ b/include/fam/fam_exception.h
@@ -67,7 +67,8 @@ enum Fam_Error {
     FAM_ERR_ATL,
     FAM_BACKUP_NOT_CREATED,
     FAM_BACKUP_NOTFOUND,
-    FAM_BACKUP_INFO_NOTFOUND
+    FAM_BACKUP_INFO_NOTFOUND,
+    FAM_ERR_NOT_PWR_TWO
 };
 
 class Fam_Exception : public std::exception {

--- a/src/cis/fam_cis_direct.cpp
+++ b/src/cis/fam_cis_direct.cpp
@@ -846,6 +846,7 @@ Fam_Region_Item_Info Fam_CIS_Direct::allocate(string name, size_t nbytes,
         ostringstream message;
         allocate_failure_cleanup(allocate_success_list, memoryServiceList,
                                  regionId, dataitem.offsets);
+        metadataService->metadata_delete_dataitem(dataitemId, regionId);
         if (allocate_failed_list.size() == 1) {
             THROW_ERRNO_MSG(CIS_Exception, (Fam_Error)ex.fam_error(),
                             ex.fam_error_msg());

--- a/src/common/fam_internal_exception.h
+++ b/src/common/fam_internal_exception.h
@@ -118,7 +118,9 @@ enum Internal_Error {
     MEMORY_SERVER_START_FAILED,
     METADATA_SERVER_START_FAILED,
     ADDRVEC_POPULATION_FAILED,
-    MEMSERVER_LIST_CREATE_FAILED
+    MEMSERVER_LIST_CREATE_FAILED,
+    DATAITEM_KEY_NOT_AVAILABLE,
+    INTERLV_SIZE_NOT_PWR_TWO
 };
 
 inline enum Fam_Error convert_to_famerror(enum Internal_Error serverErr) {
@@ -170,6 +172,9 @@ inline enum Fam_Error convert_to_famerror(enum Internal_Error serverErr) {
     case LIBFABRIC_ERROR:
     case ADDRVEC_POPULATION_FAILED:
         return FAM_ERR_LIBFABRIC;
+
+    case INTERLV_SIZE_NOT_PWR_TWO:
+        return FAM_ERR_NOT_PWR_TWO;
 
     case REGION_NOT_INSERTED:
     case DATAITEM_NOT_INSERTED:

--- a/test/unit-test/fam-api/fam_compare_swap_atomics_nvmm_test.cpp
+++ b/test/unit-test/fam-api/fam_compare_swap_atomics_nvmm_test.cpp
@@ -1,6 +1,6 @@
 /*
  * fam_compare_swap_atomics_nvmm_test.cpp
- * Copyright (c) 2019 Hewlett Packard Enterprise Development, LP. All rights
+ * Copyright (c) 2019,2022 Hewlett Packard Enterprise Development, LP. All rights
  * reserved. Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  * 1. Redistributions of source code must retain the above copyright notice,
@@ -96,7 +96,7 @@ int main() {
 
     int32_t valueInt32 = 0xAAAAAAAA;
     try {
-        my_fam->fam_set(item, 4, valueInt32);
+        my_fam->fam_set(item, 8, valueInt32);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -107,7 +107,7 @@ int main() {
     int32_t newValueInt32 = 0xBBBBBBBB;
 
     try {
-        my_fam->fam_compare_swap(item, 4, oldValueInt32, newValueInt32);
+        my_fam->fam_compare_swap(item, 8, oldValueInt32, newValueInt32);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -115,7 +115,7 @@ int main() {
     }
 
     try {
-        valueInt32 = my_fam->fam_fetch_int32(item, 4);
+        valueInt32 = my_fam->fam_fetch_int32(item, 8);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -126,7 +126,7 @@ int main() {
     // Compare atomic operation for int64
     int64_t valueInt64 = 0xBBBBBBBBBBBBBBBB;
     try {
-        my_fam->fam_set(item, 4, valueInt64);
+        my_fam->fam_set(item, 8, valueInt64);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -137,7 +137,7 @@ int main() {
     int64_t newValueInt64 = 0xCCCCCCCCCCCCCCCC;
 
     try {
-        my_fam->fam_compare_swap(item, 4, oldValueInt64, newValueInt64);
+        my_fam->fam_compare_swap(item, 8, oldValueInt64, newValueInt64);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -145,7 +145,7 @@ int main() {
     }
 
     try {
-        valueInt64 = my_fam->fam_fetch_int64(item, 4);
+        valueInt64 = my_fam->fam_fetch_int64(item, 8);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -156,7 +156,7 @@ int main() {
     // Compare atomic operations for uint32
     uint32_t valueUint32 = 0xBBBBBBBB;
     try {
-        my_fam->fam_set(item, 4, valueUint32);
+        my_fam->fam_set(item, 8, valueUint32);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -167,7 +167,7 @@ int main() {
     uint32_t newValueUint32 = 0xCCCCCCCC;
 
     try {
-        my_fam->fam_compare_swap(item, 4, oldValueUint32, newValueUint32);
+        my_fam->fam_compare_swap(item, 8, oldValueUint32, newValueUint32);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -175,7 +175,7 @@ int main() {
     }
 
     try {
-        valueUint32 = my_fam->fam_fetch_uint32(item, 4);
+        valueUint32 = my_fam->fam_fetch_uint32(item, 8);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -186,7 +186,7 @@ int main() {
     // Compare atomic operation for uint64
     uint64_t valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
-        my_fam->fam_set(item, 4, valueUint64);
+        my_fam->fam_set(item, 8, valueUint64);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -197,7 +197,7 @@ int main() {
     uint64_t newValueUint64 = 0xCCCCCCCCCCCCCCCC;
 
     try {
-        my_fam->fam_compare_swap(item, 4, oldValueUint64, newValueUint64);
+        my_fam->fam_compare_swap(item, 8, oldValueUint64, newValueUint64);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -205,7 +205,7 @@ int main() {
     }
 
     try {
-        valueUint64 = my_fam->fam_fetch_uint64(item, 4);
+        valueUint64 = my_fam->fam_fetch_uint64(item, 8);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -216,7 +216,7 @@ int main() {
     // Failure test case
     valueUint64 = 0xBBBBBBBBBBBBBBBB;
     try {
-        my_fam->fam_set(item, 4, valueUint64);
+        my_fam->fam_set(item, 8, valueUint64);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -227,7 +227,7 @@ int main() {
     newValueUint64 = 0xCCCCCCCCCCCCCCCC;
 
     try {
-        my_fam->fam_compare_swap(item, 4, oldValueUint64, newValueUint64);
+        my_fam->fam_compare_swap(item, 8, oldValueUint64, newValueUint64);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;
@@ -235,7 +235,7 @@ int main() {
     }
 
     try {
-        valueUint64 = my_fam->fam_fetch_uint64(item, 4);
+        valueUint64 = my_fam->fam_fetch_uint64(item, 8);
     } catch (Fam_Exception &e) {
         cout << "Exception caught" << endl;
         cout << "Error msg: " << e.fam_error_msg() << endl;

--- a/tools/openfam_adm.py
+++ b/tools/openfam_adm.py
@@ -380,7 +380,7 @@ if args.create_config_files:
     else:
         metaservice_config_doc["enable_region_spanning"] = bool(1)
     if args.regionspanningsize is not None:
-        metaservice_config_doc["region_span_size_per_memoryserver"] = (
+        metaservice_config_doc["region_span_size_per_memoryserver"] = int(
             args.regionspanningsize
         )
 


### PR DESCRIPTION
2. Remove metadata on registration failure during allocation
3. Added check to see if interleave size is power of 2. 
4. Shared memory atomics test case failure with Misaligned Offset error