### PR TITLE
Fixing Compilation and build errors

### DIFF
--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -4,6 +4,7 @@ BUILD_DIR=$CURRENTDIR/build/
 TOOL_DIR=$CURRENTDIR/tools
 MAKE_CMD="make -j"
 THIRDPARTY_BUILD=$CURRENTDIR/third-party/build/
+INSTALL_DIR=$BUILD_DIR
 
 #creating build directory if not present
 if [ ! -d "$BUILD_DIR" ]; then
@@ -16,6 +17,7 @@ export LD_LIBRARY_PATH=$THIRDPARTY_BUILD/lib/:$THIRDPARTY_BUILD/lib64/:$LD_LIBRA
 
 #Build and run test with MemoryServer allocator
 cd $BUILD_DIR
+
 cmake ..; $MAKE_CMD ; make install
 if [[ $? > 0 ]]
 then
@@ -28,7 +30,7 @@ echo "Test OpenFAM with cis-rpc-meta-direct-mem-rpc configuration"
 echo "==========================================================="
 CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-cis-rpc-meta-direct-mem-rpc
 export OPENFAM_ROOT=$CONFIG_OUT_DIR
-$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $CURRENTDIR --model memory_server --cisinterface rpc --memserverinterface rpc --metaserverinterface direct --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
+$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $INSTALL_DIR --model memory_server --cisinterface rpc --memserverinterface rpc --metaserverinterface direct --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
 if [[ $? > 0 ]]
 then
         echo "OpenFAM test with cis-rpc-meta-direct-mem-rpc configuration failed. exit..."
@@ -46,7 +48,7 @@ echo "Test OpenFAM with cis-rpc-meta-rpc-mem-rpc configuration"
 echo "========================================================"
 CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-cis-rpc-meta-rpc-mem-rpc
 export OPENFAM_ROOT=$CONFIG_OUT_DIR
-$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $CURRENTDIR --model memory_server --cisinterface rpc --memserverinterface rpc --metaserverinterface rpc --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
+$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $INSTALL_DIR --model memory_server --cisinterface rpc --memserverinterface rpc --metaserverinterface rpc --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
 
 if [[ $? > 0 ]]
 then
@@ -65,7 +67,7 @@ echo "Test OpenFAM with cis-rpc-meta-direct-mem-direct configuration"
 echo "=============================================================="
 CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-cis-rpc-meta-direct-mem-direct
 export OPENFAM_ROOT=$CONFIG_OUT_DIR
-$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $CURRENTDIR --model memory_server --cisinterface rpc --memserverinterface direct --metaserverinterface direct --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
+$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $INSTALL_DIR --model memory_server --cisinterface rpc --memserverinterface direct --metaserverinterface direct --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
 
 if [[ $? > 0 ]]
 then
@@ -84,7 +86,7 @@ echo "Test OpenFAM with cis-direct-meta-rpc-mem-rpc configuration"
 echo "==========================================================="
 CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-cis-direct-meta-rpc-mem-rpc
 export OPENFAM_ROOT=$CONFIG_OUT_DIR
-$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $CURRENTDIR --model memory_server --cisinterface direct --memserverinterface rpc --metaserverinterface rpc --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
+$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $INSTALL_DIR --model memory_server --cisinterface direct --memserverinterface rpc --metaserverinterface rpc --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
 
 if [[ $? > 0 ]]
 then
@@ -103,7 +105,7 @@ echo "Test OpenFAM with shared memory configuration"
 echo "==========================================================="
 CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-shared-memory
 export OPENFAM_ROOT=$CONFIG_OUT_DIR
-$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $CURRENTDIR --model shared_memory --cisinterface direct --memserverinterface direct --metaserverinterface direct --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
+$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/common-config-arg.txt --install_path $INSTALL_DIR --model shared_memory --cisinterface direct --memserverinterface direct --metaserverinterface direct --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
 
 if [[ $? > 0 ]]
 then
@@ -122,7 +124,7 @@ echo "Test OpenFAM with multiple memory servers in all rpc configuration"
 echo "==========================================================="
 CONFIG_OUT_DIR=$BUILD_DIR/test/config_files/config-multi-mem
 export OPENFAM_ROOT=$CONFIG_OUT_DIR
-$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/multi-mem-config-arg.txt --install_path $CURRENTDIR --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
+$BUILD_DIR/bin/openfam_adm @$TOOL_DIR/multi-mem-config-arg.txt --install_path $INSTALL_DIR --create_config_files --config_file_path $CONFIG_OUT_DIR --start_service --runtests
 
 if [[ $? > 0 ]]
 then

--- a/src/metadata_service/fam_metadata_service_direct.cpp
+++ b/src/metadata_service/fam_metadata_service_direct.cpp
@@ -2369,7 +2369,6 @@ void Fam_Metadata_Service_Direct::Impl_::metadata_validate_and_create_region(
 
     // Call get_regionid_from_bitmap to get regionID
     int ret = get_regionid_from_bitmap(regionid);
-
     if (ret == META_NO_FREE_REGIONID) {
         message << "Create region error : No free RegionID.";
         THROW_ERRNO_MSG(Metadata_Service_Exception, NO_FREE_POOLID,
@@ -2480,7 +2479,8 @@ void Fam_Metadata_Service_Direct::Impl_::
     }
 
     // Check if the interleave size if power of two
-    if (!is_power_of_two(region.interleaveSize)) {
+    if (region.interleaveEnable == ENABLE &&
+        !is_power_of_two(region.interleaveSize)) {
         message << "Interleave size is not power of two";
         THROW_ERRNO_MSG(Metadata_Service_Exception, INTERLV_SIZE_NOT_PWR_TWO,
                         message.str().c_str());
@@ -3126,7 +3126,7 @@ Fam_Metadata_Service_Direct::get_config_info(std::string filename) {
         try {
             options["dataitem_interleave_size"] = (char *)strdup(
                 (info->get_key_value("dataitem_interleave_size")).c_str());
-        } catch (Fam_InvalidOption_Exception e) {
+        } catch (Fam_InvalidOption_Exception &e) {
             // If parameter is not present, then set the default.
             options["dataitem_interleave_size"] = (char *)strdup("1048576");
         }

--- a/third-party/build.sh
+++ b/third-party/build.sh
@@ -121,7 +121,7 @@ function get_os_release_version(){
 
 ubuntu18_package_list="build-essential cmake autoconf libtool pkg-config libpthread-stubs0-dev libevent-2.1-6 libevent-dev flex hwloc libhwloc-dev libhwloc-plugins libyaml-cpp-dev libpmem-dev libpmem1 libboost-all-dev python python3 python-pip python3-pip"
 
-ubuntu20_package_list="build-essential cmake autoconf libtool pkg-config libyaml-cpp-dev python3 python3-pip libevent-dev flex hwloc libhwloc-dev libhwloc-plugins libpmem-dev libpmem1 libboost-all-dev python3 python3-pip"
+ubuntu20_package_list="build-essential cmake autoconf libtool pkg-config libyaml-cpp-dev python3 python3-pip libevent-dev flex hwloc libhwloc-dev libhwloc-plugins libpmem-dev libpmem1 libboost-all-dev python3 python3-pip libssl-dev"
 
 rhel8_package_list="gcc gcc-c++ python3 python3-pip cmake make kernel-devel libevent libevent-devel glibc automake epel-release boost-devel-1.66.0 libpmem libpmem-devel yaml-cpp yaml-cpp-devel flex"
 

--- a/tools/openfam_adm.py
+++ b/tools/openfam_adm.py
@@ -880,14 +880,14 @@ if args.runtests:
         )
 
     # Run regression and unit tests
-    cmd = "cd " + openfam_install_path + "/build; " + " make reg-test"
+    cmd = "cd " + openfam_install_path + "; " + " make reg-test"
     result = os.system(cmd)
     if (result >> 8) != 0:
         error_count = error_count + 1
         print('\033[1;31;40mERROR['+str(error_count) +
               ']: Regression test failed \033[0;37;40m')
         sys.exit(1)
-    cmd = "cd " + openfam_install_path + "/build; " + " make unit-test"
+    cmd = "cd " + openfam_install_path + "; " + " make unit-test"
     result = os.system(cmd)
     if (result >> 8) != 0:
         error_count = error_count + 1

--- a/tools/openfam_adm.py
+++ b/tools/openfam_adm.py
@@ -859,7 +859,7 @@ if args.runtests:
             os.environ["OPENFAM_TEST_OPT"] = ""
         else:
             os.environ["OPENFAM_TEST_COMMAND"] = openfam_install_path + \
-                "/third-party/build/bin/mpirun"
+                "/../third-party/build/bin/mpirun"
             os.environ["OPENFAM_TEST_OPT"] = (
                 "-n "
                 + str(npe) + " "

--- a/tools/openfam_adm.py
+++ b/tools/openfam_adm.py
@@ -681,6 +681,11 @@ ssh_cmd = "ssh " + os.environ["USER"] + "@"
 if args.start_service:
     openfam_install_path = get_install_path()
     service_info = []
+    # unset http_proxy and https_proxy if they are set
+    os.environ.pop('http_proxy', None)
+    os.environ.pop('https_proxy', None)
+    os.environ.pop('HTTP_PROXY', None)
+    os.environ.pop('HTTPS_PROXY', None)
     # start all memory services
     if (
         pe_config_doc["openfam_model"] == "memory_server"


### PR DESCRIPTION
Fixing Compilation and build error

1. If set, unset http_proxy, https_proxy 
5. Compiler warning in Ubuntu 20.4
9. Fix the directory path in "cd" command before running tests

