### PR TITLE
Context and interleaving changes

### DIFF
--- a/src/common/fam_ops.h
+++ b/src/common/fam_ops.h
@@ -734,7 +734,7 @@ class Fam_Ops {
      * context_open, context_close, get_context_id
      * These APIs are added to support user specific communication context
      */
-    virtual void context_open(uint64_t) = 0;
+    virtual void context_open(uint64_t, Fam_Ops *) = 0;
     virtual void context_close(uint64_t) = 0;
     virtual uint64_t get_context_id() = 0;
 

--- a/src/common/fam_ops_libfabric.h
+++ b/src/common/fam_ops_libfabric.h
@@ -326,7 +326,7 @@ class Fam_Ops_Libfabric : public Fam_Ops {
                               uint32_t value);
     uint64_t atomic_fetch_xor(Fam_Descriptor *descriptor, uint64_t offset,
                               uint64_t value);
-    void context_open(uint64_t contextId);
+    void context_open(uint64_t contextId, Fam_Ops *famOpsObj);
     void context_close(uint64_t contextId);
     /**
      * Routines to access protected members
@@ -375,6 +375,8 @@ class Fam_Ops_Libfabric : public Fam_Ops {
     uint64_t get_context_id() { return ctxId; };
 
     void set_context_id(uint64_t contextID) { ctxId = contextID; };
+    Fam_Context *get_context() { return ctxObj; };
+    void set_context(Fam_Context *ctx) { ctxObj = ctx; };
 
     pthread_rwlock_t *get_mr_lock() { return &fiMrLock; };
 
@@ -448,6 +450,7 @@ class Fam_Ops_Libfabric : public Fam_Ops {
     Fam_Thread_Model famThreadModel;
     Fam_Context_Model famContextModel;
     Fam_Allocator_Client *famAllocator;
+    Fam_Context *ctxObj;
 };
 } // namespace openfam
 #endif

--- a/src/common/fam_ops_shm.h
+++ b/src/common/fam_ops_shm.h
@@ -273,7 +273,7 @@ class Fam_Ops_SHM : public Fam_Ops {
                            float value);
     double atomic_fetch_max(Fam_Descriptor *descriptor, uint64_t offset,
                             double value);
-    void *context_open();
+    void context_open(uint64_t contextId, Fam_Ops *famOpsObj);
     void context_close(void *);
 
     uint32_t atomic_fetch_and(Fam_Descriptor *descriptor, uint64_t offset,

--- a/src/fam-api/fam.cpp
+++ b/src/fam-api/fam.cpp
@@ -130,7 +130,7 @@ class fam::Impl_ {
         } else {
             famOps = new Fam_Ops_Libfabric((Fam_Ops_Libfabric *)pimpl->famOps);
             ctxId = famOps->get_context_id();
-            pimpl->famOps->context_open(ctxId);
+            pimpl->famOps->context_open(ctxId, famOps);
         }
         famAllocator = pimpl->famAllocator;
         famRuntime = pimpl->famRuntime;

--- a/src/fam-api/fam_ops_libfabric.cpp
+++ b/src/fam-api/fam_ops_libfabric.cpp
@@ -440,6 +440,7 @@ int Fam_Ops_Libfabric::put_blocking(void *local, Fam_Descriptor *descriptor,
             famCtx->aquire_RDLock();
             try {
                 ret = fabric_completion_wait(famCtx, ctx, 0);
+                delete ctx;
             } catch (...) {
                 famCtx->inc_num_tx_fail_cnt(1l);
                 // Release Fam_Context read lock
@@ -543,6 +544,7 @@ int Fam_Ops_Libfabric::put_blocking(void *local, Fam_Descriptor *descriptor,
         for (auto ctx : fiCtxVector) {
             try {
                 ret = fabric_completion_wait(famCtx, ctx, 0);
+                delete ctx;
             } catch (...) {
                 famCtx->inc_num_tx_fail_cnt(1l);
                 // Release Fam_Context read lock
@@ -591,6 +593,7 @@ int Fam_Ops_Libfabric::get_blocking(void *local, Fam_Descriptor *descriptor,
             famCtx->aquire_RDLock();
             try {
                 ret = fabric_completion_wait(famCtx, ctx, 0);
+                delete ctx;
             } catch (...) {
                 famCtx->inc_num_rx_fail_cnt(1l);
                 // Release Fam_Context read lock
@@ -693,6 +696,7 @@ int Fam_Ops_Libfabric::get_blocking(void *local, Fam_Descriptor *descriptor,
         for (auto ctx : fiCtxVector) {
             try {
                 ret = fabric_completion_wait(famCtx, ctx, 0);
+                delete ctx;
             } catch (...) {
                 famCtx->inc_num_rx_fail_cnt(1l);
                 // Release Fam_Context read lock
@@ -738,6 +742,7 @@ int Fam_Ops_Libfabric::scatter_blocking(void *local, Fam_Descriptor *descriptor,
         famCtx->aquire_RDLock();
         try {
             ret = fabric_completion_wait(famCtx, ctx, 0);
+            delete ctx;
         } catch (...) {
             famCtx->inc_num_tx_fail_cnt(1l);
             // Release Fam_Context read lock
@@ -839,6 +844,7 @@ int Fam_Ops_Libfabric::scatter_blocking(void *local, Fam_Descriptor *descriptor,
         for (auto ctx : fiCtxVector) {
             try {
                 ret = fabric_completion_wait(famCtx, ctx, 0);
+                delete ctx;
             } catch (...) {
                 famCtx->inc_num_tx_fail_cnt(1l);
                 // Release Fam_Context read lock
@@ -884,6 +890,7 @@ int Fam_Ops_Libfabric::gather_blocking(void *local, Fam_Descriptor *descriptor,
         famCtx->aquire_RDLock();
         try {
             ret = fabric_completion_wait(famCtx, ctx, 0);
+            delete ctx;
         } catch (...) {
             famCtx->inc_num_rx_fail_cnt(1l);
             // Release Fam_Context read lock
@@ -985,6 +992,7 @@ int Fam_Ops_Libfabric::gather_blocking(void *local, Fam_Descriptor *descriptor,
         for (auto ctx : fiCtxVector) {
             try {
                 ret = fabric_completion_wait(famCtx, ctx, 0);
+                delete ctx;
             } catch (...) {
                 famCtx->inc_num_rx_fail_cnt(1l);
                 // Release Fam_Context read lock
@@ -1030,6 +1038,7 @@ int Fam_Ops_Libfabric::scatter_blocking(void *local, Fam_Descriptor *descriptor,
         famCtx->aquire_RDLock();
         try {
             ret = fabric_completion_wait(famCtx, ctx, 0);
+            delete ctx;
         } catch (...) {
             famCtx->inc_num_tx_fail_cnt(1l);
             // Release Fam_Context read lock
@@ -1131,6 +1140,7 @@ int Fam_Ops_Libfabric::scatter_blocking(void *local, Fam_Descriptor *descriptor,
         for (auto ctx : fiCtxVector) {
             try {
                 ret = fabric_completion_wait(famCtx, ctx, 0);
+                delete ctx;
             } catch (...) {
                 famCtx->inc_num_tx_fail_cnt(1l);
                 // Release Fam_Context read lock
@@ -1176,6 +1186,7 @@ int Fam_Ops_Libfabric::gather_blocking(void *local, Fam_Descriptor *descriptor,
         famCtx->aquire_RDLock();
         try {
             ret = fabric_completion_wait(famCtx, ctx, 0);
+            delete ctx;
         } catch (...) {
             famCtx->inc_num_rx_fail_cnt(1l);
             // Release Fam_Context read lock
@@ -1277,6 +1288,7 @@ int Fam_Ops_Libfabric::gather_blocking(void *local, Fam_Descriptor *descriptor,
         for (auto ctx : fiCtxVector) {
             try {
                 ret = fabric_completion_wait(famCtx, ctx, 0);
+                delete ctx;
             } catch (...) {
                 famCtx->inc_num_rx_fail_cnt(1l);
                 // Release Fam_Context read lock

--- a/src/fam-api/fam_ops_shm.cpp
+++ b/src/fam-api/fam_ops_shm.cpp
@@ -2300,7 +2300,9 @@ uint64_t Fam_Ops_SHM::atomic_fetch_xor(Fam_Descriptor *descriptor,
     return *oldValue;
 }
 
-void Fam_Ops_SHM::context_open(uint64_t contextId) { return; }
+void Fam_Ops_SHM::context_open(uint64_t contextId, Fam_Ops *famOpsObj) {
+    return;
+}
 
 void Fam_Ops_SHM::context_close(uint64_t contextId) { return; }
 

--- a/test/reg-test/fam-api-reg/fam_dataitem_interleave_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_dataitem_interleave_test.cpp
@@ -39,6 +39,9 @@
 
 #define ITERATION 10
 #define FILE_MAX_LEN 255
+#define TEST_REGION_SIZE 104857600
+#define TEST_ALLOCATE_SIZE 16777216
+#define TEST_OFFSET 1048576
 
 using namespace std;
 using namespace openfam;
@@ -557,6 +560,121 @@ TEST(DataitemInterleaving, CreateDataitemRestoreSuccess) {
 
     free((void *)testRegion);
     free((void *)secondItem);
+    free((void *)firstItem);
+}
+TEST(DataitemInterleaving, AtomicCallsSuccess) {
+    Fam_Region_Descriptor *desc;
+    Fam_Descriptor *descriptor;
+    int32_t value = 0x444;
+    int64_t value1 = 0x1fffffffffffffff;
+    uint32_t value2 = 0xefffffff;
+    uint64_t value3 = 0x7fffffffffffffff;
+    float value4 = 4.3f;
+    double value5 = 4.4e+38;
+    int128_t value6 = 1;
+
+    const char *testRegion = get_uniq_str("test", my_fam);
+    const char *firstItem = get_uniq_str("first", my_fam);
+
+    EXPECT_NO_THROW(desc = my_fam->fam_create_region(
+                        testRegion, TEST_REGION_SIZE, 0777, NULL));
+    EXPECT_NE((void *)NULL, desc);
+    // Allocating data items in the created region
+    EXPECT_NO_THROW(descriptor = my_fam->fam_allocate(
+                        firstItem, TEST_ALLOCATE_SIZE, 0777, desc));
+    EXPECT_NE((void *)NULL, descriptor);
+    EXPECT_NO_THROW(value = my_fam->fam_fetch_int32(descriptor, TEST_OFFSET));
+    EXPECT_NO_THROW(value1 = my_fam->fam_fetch_int64(descriptor, TEST_OFFSET));
+    EXPECT_NO_THROW(value2 = my_fam->fam_fetch_uint32(descriptor, TEST_OFFSET));
+    EXPECT_NO_THROW(value3 = my_fam->fam_fetch_uint64(descriptor, TEST_OFFSET));
+    EXPECT_NO_THROW(value4 = my_fam->fam_fetch_float(descriptor, TEST_OFFSET));
+    EXPECT_NO_THROW(value5 = my_fam->fam_fetch_double(descriptor, TEST_OFFSET));
+    EXPECT_NO_THROW(value6 = my_fam->fam_fetch_int128(descriptor, TEST_OFFSET));
+
+    EXPECT_NO_THROW((void)my_fam->fam_swap(descriptor, TEST_OFFSET, value));
+    EXPECT_NO_THROW((void)my_fam->fam_swap(descriptor, TEST_OFFSET, value1));
+    EXPECT_NO_THROW((void)my_fam->fam_swap(descriptor, TEST_OFFSET, value2));
+    EXPECT_NO_THROW((void)my_fam->fam_swap(descriptor, TEST_OFFSET, value3));
+    EXPECT_NO_THROW((void)my_fam->fam_swap(descriptor, TEST_OFFSET, value4));
+    EXPECT_NO_THROW((void)my_fam->fam_swap(descriptor, TEST_OFFSET, value5));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_compare_swap(descriptor, TEST_OFFSET, value, value));
+    EXPECT_NO_THROW((void)my_fam->fam_compare_swap(descriptor, TEST_OFFSET,
+                                                   value1, value1));
+    EXPECT_NO_THROW((void)my_fam->fam_compare_swap(descriptor, TEST_OFFSET,
+                                                   value2, value2));
+    EXPECT_NO_THROW((void)my_fam->fam_compare_swap(descriptor, TEST_OFFSET,
+                                                   value3, value3));
+    EXPECT_NO_THROW((void)my_fam->fam_compare_swap(descriptor, TEST_OFFSET,
+                                                   value6, value6));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_add(descriptor, TEST_OFFSET, value));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_add(descriptor, TEST_OFFSET, value1));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_add(descriptor, TEST_OFFSET, value2));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_add(descriptor, TEST_OFFSET, value3));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_add(descriptor, TEST_OFFSET, value4));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_add(descriptor, TEST_OFFSET, value5));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_subtract(descriptor, TEST_OFFSET, value));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_subtract(descriptor, TEST_OFFSET, value1));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_subtract(descriptor, TEST_OFFSET, value2));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_subtract(descriptor, TEST_OFFSET, value3));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_subtract(descriptor, TEST_OFFSET, value4));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_subtract(descriptor, TEST_OFFSET, value5));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_min(descriptor, TEST_OFFSET, value));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_min(descriptor, TEST_OFFSET, value1));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_min(descriptor, TEST_OFFSET, value2));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_min(descriptor, TEST_OFFSET, value3));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_min(descriptor, TEST_OFFSET, value4));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_min(descriptor, TEST_OFFSET, value5));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_and(descriptor, TEST_OFFSET, value2));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_and(descriptor, TEST_OFFSET, value3));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_max(descriptor, TEST_OFFSET, value));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_max(descriptor, TEST_OFFSET, value1));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_max(descriptor, TEST_OFFSET, value2));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_max(descriptor, TEST_OFFSET, value3));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_max(descriptor, TEST_OFFSET, value4));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_max(descriptor, TEST_OFFSET, value5));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_or(descriptor, TEST_OFFSET, value2));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_or(descriptor, TEST_OFFSET, value3));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_xor(descriptor, TEST_OFFSET, value2));
+    EXPECT_NO_THROW(
+        (void)my_fam->fam_fetch_xor(descriptor, TEST_OFFSET, value3));
+
+    EXPECT_NO_THROW(my_fam->fam_deallocate(descriptor));
+
+    EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
+    delete descriptor;
+    delete desc;
+
+    free((void *)testRegion);
     free((void *)firstItem);
 }
 


### PR DESCRIPTION
Context and interleaving changes:
1. Free ctx structure after fabric_completion_wait in blocking calls
2. Coverage of all atomic APIs in interleaving tests
3. Fixed the error: context for memserver not found
