### PR TITLE
Libfabric, script fixes and compilation warnings

### DIFF
--- a/test/apps/pagerank/fam_csr_preload_parmat.cpp
+++ b/test/apps/pagerank/fam_csr_preload_parmat.cpp
@@ -1,6 +1,6 @@
 /*
  * fam_csr_preload_parmat.cpp
- * Copyright (c) 2019-2020 Hewlett Packard Enterprise Development, LP. All
+ * Copyright (c) 2019-2022 Hewlett Packard Enterprise Development, LP. All
  * rights reserved. Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
  * are met:
@@ -76,25 +76,25 @@ int LoadGraphMatrix(std::istream& istream, size_t num_rows, size_t num_elements,
     // write rowptr to fam
     if (load_dataitem((char*)rowptr, "rowptr0", 0, 
                        (num_rows+1)*sizeof(int64_t), region, perm) < 0) {
-        free(rowptr);
-        free(colptr);
-        free(valptr);
+        delete rowptr;
+        delete colptr;
+        delete valptr;
         return -1;
     }
     // write colptr to fam
     if (load_dataitem((char*)colptr, "colptr0", 0,
                        (count)*sizeof(int64_t), region, perm) < 0) {
-        free(rowptr);
-        free(colptr);
-        free(valptr);
+        delete rowptr;
+        delete colptr;
+        delete valptr;
         return -1;
     }
     // write valptr to fam
     if (load_dataitem((char*)valptr, "valptr0", 0,
                        (count)*sizeof(int64_t), region, perm) < 0) {
-        free(rowptr);
-        free(colptr);
-        free(valptr);
+        delete rowptr;
+        delete colptr;
+        delete valptr;
         return -1;
     } 
                

--- a/tools/openfam_adm.py
+++ b/tools/openfam_adm.py
@@ -913,11 +913,16 @@ if args.stop_service:
                 memory_server_id = server.split(":")[0]
                 memory_server_addr = server.split(":")[1]
                 key_string="openfam:mem:"+server
-                cmd="squeue --me -O JobId,Command,Comment | grep " + key_string + " | cut -d' ' -f1"
+                #Following squeue command lists the JobId(%i), Job Name(%j) and Comment(%k)
+                #for all jobs run by current user.
+                cmd="squeue --me --format=\"%i %20j %.50k\" | grep " + key_string + " | cut -d' ' -f1"
                 out=subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout;
                 job_id=out.read().decode()
-                cmd="scancel " + "--user=" + user + " --nodelist=" + memory_server_addr + " --quiet " + str(job_id) +" > /dev/null 2>&1"
-                os.system(cmd)
+                if (job_id == ""):
+                    print("No job ids found for the OpenFAM Memory Service for given configuration.")
+                else:
+                    cmd="scancel " + "--user=" + user + " --nodelist=" + memory_server_addr + " --quiet " + str(job_id) +" > /dev/null 2>&1"
+                    os.system(cmd)
         else:
             cmd = "pkill -9 memory_server"
             os.system(cmd)
@@ -940,11 +945,16 @@ if args.stop_service:
             for server in cis_config_doc["metadata_list"]:
                 metadata_server_addr = server.split(":")[1]
                 key_string="openfam:meta:"+server
-                cmd="squeue --me -O JobId,Command,Comment | grep " + key_string + " | cut -d' ' -f1"
+                #Following squeue command lists the JobId(%i), Job Name(%j) and Comment(%k)
+                #for all jobs run by current user.
+                cmd="squeue --me --format=\"%i %20j %.50k\" | grep " + key_string + " | cut -d' ' -f1"
                 out=subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout;
                 job_id=out.read().decode()
-                cmd="scancel " + "--user=" + user + " --nodelist=" + metadata_server_addr + " --quiet " + str(job_id) +" > /dev/null 2>&1"
-                os.system(cmd)
+                if (job_id == ""):
+                    print("No job id found for the OpenFAM Metadata Service for given configuration.")
+                else:
+                    cmd="scancel " + "--user=" + user + " --nodelist=" + metadata_server_addr + " --quiet " + str(job_id) +" > /dev/null 2>&1"
+                    os.system(cmd)
         else:
             cmd = "pkill -9 metadata_server"
             os.system(cmd)
@@ -959,11 +969,16 @@ if args.stop_service:
             user = os.environ["USER"]
             cis_addr = cis_config_doc["rpc_interface"].split(":")[0]
             key_string="openfam:cis:"+cis_config_doc["rpc_interface"]
-            cmd="squeue --me -O JobId,Command,Comment | grep " + key_string + " | cut -d' ' -f1"
+            #Following squeue command lists the JobId(%i), Job Name(%j) and Comment(%k)
+            #for all jobs run by current user.
+            cmd="squeue --me --format=\"%i %20j %.50k\" | grep " + key_string + " | cut -d' ' -f1"
             out=subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout;
             job_id=out.read().decode()
-            cmd="scancel " + "--user=" + user + " --nodelist=" + cis_addr + " --quiet " + str(job_id) +" > /dev/null 2>&1"
-            os.system(cmd)
+            if (job_id == ""):
+                print("No job ids found for the OpenFAM CIS Service for given configuration.")
+            else:
+                cmd="scancel " + "--user=" + user + " --nodelist=" + cis_addr + " --quiet " + str(job_id) +" > /dev/null 2>&1"
+                os.system(cmd)
         else:
             cmd = "pkill -9 cis_server"
         os.system(cmd)


### PR DESCRIPTION
Fixing the FI_ENOMEM error returned by libfabric 
Fixed openfam_adm to consider squeue comment of bigger length
Fix for mismatched-new-delete warning in new compiler versions 