### PR TITLE
Adding a new allocation policy to allocate entire region space

### DIFF
--- a/include/fam/fam.h
+++ b/include/fam/fam.h
@@ -46,7 +46,7 @@
  *
  * Work in progress, UNSTABLE
  * Uses _Generic and 128-bit integer types, tested under gcc 6.3.0. May require
- * “-std=c11” compiler flag if you are using the generic API as documented in
+ * ï¿½-std=c11ï¿½ compiler flag if you are using the generic API as documented in
  * OpenFAM-API-v104.
  *
  * Programming conventions used in the API:
@@ -115,11 +115,22 @@ typedef enum {
     DATAITEM
 } Fam_Permission_Level;
 
+typedef enum {
+    /** Deafault value **/
+    ALLOCATION_POLICY_DEFAULT = 0,
+    /** Region created in single node and only one data item can be allocated which spans entire region **/
+    SINGLE_NODE_SINGLE_ALLOC,
+    /** Region can be created in multiple node and multiple data items are supported**/
+    MULTI_NODE_MULTI_ALLOC
+} Fam_Allocation_Policy;
+
 typedef struct {
     Fam_Redundancy_Level redundancyLevel;
     Fam_Memory_Type memoryType;
     Fam_Interleave_Enable interleaveEnable;
     Fam_Permission_Level permissionLevel;
+    Fam_Allocation_Policy allocationPolicy;
+    int hostingNode;
 } Fam_Region_Attributes;
 
 /**
@@ -336,10 +347,12 @@ class Fam_Region_Descriptor {
     void set_memoryType(Fam_Memory_Type memoryType);
     void set_interleaveEnable(Fam_Interleave_Enable interleaveEnable);
     void set_permissionLevel(Fam_Permission_Level permissionLevel);
+    void set_allocationPolicy(Fam_Allocation_Policy allocPolicy);
     Fam_Redundancy_Level get_redundancyLevel();
     Fam_Memory_Type get_memoryType();
     Fam_Interleave_Enable get_interleaveEnable();
     Fam_Permission_Level get_permissionLevel();
+    Fam_Allocation_Policy get_allocationPolicy();
     // get size, perm and name.
     uint64_t get_size();
     mode_t get_perm();

--- a/src/allocator/fam_allocator_client.cpp
+++ b/src/allocator/fam_allocator_client.cpp
@@ -187,6 +187,7 @@ Fam_Allocator_Client::create_region(const char *name, uint64_t nbytes,
     region->set_memoryType(regionAttributes->memoryType);
     region->set_interleaveEnable(regionAttributes->interleaveEnable);
     region->set_permissionLevel(regionAttributes->permissionLevel);
+    region->set_allocationPolicy(regionAttributes->allocationPolicy);
     region->set_name((char *)name);
     region->set_perm(permissions);
     region->set_desc_status(DESC_INIT_DONE);
@@ -478,6 +479,7 @@ Fam_Region_Descriptor *Fam_Allocator_Client::lookup_region(const char *name) {
     region->set_memoryType(info.memoryType);
     region->set_interleaveEnable(info.interleaveEnable);
     region->set_permissionLevel(info.permissionLevel);
+    region->set_allocationPolicy(info.allocationPolicy);
     return region;
 }
 

--- a/src/allocator/memserver_allocator.h
+++ b/src/allocator/memserver_allocator.h
@@ -49,7 +49,6 @@
 #include "common/fam_internal_exception.h"
 #include "fam/fam.h"
 
-#define MIN_OBJ_SIZE 128
 #define MIN_REGION_SIZE (1UL << 20)
 #define MIN_INFO_SIZE (1UL << 8)
 #define BACKUP_META_SIZE (1UL << 12)

--- a/src/cis/fam_cis_client.cpp
+++ b/src/cis/fam_cis_client.cpp
@@ -122,6 +122,8 @@ Fam_CIS_Client::create_region(string name, size_t nbytes, mode_t permission,
     req.set_memorytype(regionAttributes->memoryType);
     req.set_interleaveenable(regionAttributes->interleaveEnable);
     req.set_permissionlevel(regionAttributes->permissionLevel);
+    req.set_allocpolicy(regionAttributes->allocationPolicy);
+    req.set_hostingnode(regionAttributes->hostingNode);
     req.set_uid(uid);
     req.set_gid(gid);
 
@@ -297,6 +299,7 @@ Fam_Region_Item_Info Fam_CIS_Client::lookup_region(string name, uint32_t uid,
     info.memoryType = (Fam_Memory_Type)res.memorytype();
     info.interleaveEnable = (Fam_Interleave_Enable)res.interleaveenable();
     info.permissionLevel = (Fam_Permission_Level)res.permissionlevel();
+    info.allocationPolicy = (Fam_Allocation_Policy)res.allocpolicy();
     return info;
 }
 
@@ -358,6 +361,7 @@ Fam_Region_Item_Info Fam_CIS_Client::check_permission_get_region_info(
     info.interleaveEnable = (Fam_Interleave_Enable)res.interleaveenable();
     info.interleaveSize = res.interleavesize();
     info.permissionLevel = (Fam_Permission_Level)res.permissionlevel();
+    info.allocationPolicy = (Fam_Allocation_Policy)res.allocpolicy();
     info.used_memsrv_cnt = res.memsrv_list_size();
     for (uint64_t i = 0; i < info.used_memsrv_cnt; i++) {
         info.memoryServerIds[i] = res.memsrv_list((int)i);

--- a/src/cis/fam_cis_direct.cpp
+++ b/src/cis/fam_cis_direct.cpp
@@ -56,7 +56,6 @@
 #endif
 
 #define MIN_REGION_SIZE (1UL << 20)
-#define MIN_OBJ_SIZE 128
 
 using namespace std;
 using namespace chrono;
@@ -603,6 +602,7 @@ Fam_CIS_Direct::create_region(string name, size_t nbytes, mode_t permission,
     region.memoryType = regionAttributes->memoryType;
     region.interleaveEnable = regionAttributes->interleaveEnable;
     region.permissionLevel = regionAttributes->permissionLevel;
+    region.allocationPolicy = regionAttributes->allocationPolicy;
     region.used_memsrv_cnt = used_memsrv_cnt;
     memcpy(region.memServerIds, memServerIds,
            used_memsrv_cnt * sizeof(uint64_t));
@@ -1559,6 +1559,7 @@ Fam_Region_Item_Info Fam_CIS_Direct::lookup_region(string name, uint32_t uid,
     info.memoryType = region.memoryType;
     info.interleaveEnable = region.interleaveEnable;
     info.permissionLevel = region.permissionLevel;
+    info.allocationPolicy = region.allocationPolicy;
     CIS_DIRECT_PROFILE_END_OPS(cis_lookup_region);
     return info;
 }
@@ -1640,6 +1641,7 @@ Fam_Region_Item_Info Fam_CIS_Direct::check_permission_get_region_info(
     info.uid = region.uid;
     info.gid = region.gid;
     info.permissionLevel = region.permissionLevel;
+    info.allocationPolicy = region.allocationPolicy;
     memcpy(info.memoryServerIds, region.memServerIds,
            region.used_memsrv_cnt * sizeof(uint64_t));
     CIS_DIRECT_PROFILE_END_OPS(cis_check_permission_get_region_info);
@@ -2287,13 +2289,6 @@ void Fam_CIS_Direct::release_CAS_lock(uint64_t offset,
     Fam_Memory_Service *memoryService = get_memory_service(memoryServerId);
     memoryService->release_CAS_lock(offset);
     CIS_DIRECT_PROFILE_END_OPS(cis_release_CAS_lock);
-}
-
-uint64_t Fam_CIS_Direct::get_dataitem_id(uint64_t offset,
-                                         uint64_t memoryServerId) {
-    uint64_t dataitemId = memoryServerId << 48;
-    dataitemId |= offset / MIN_OBJ_SIZE;
-    return dataitemId;
 }
 
 size_t Fam_CIS_Direct::get_addr_size(uint64_t memoryServerId) {

--- a/src/cis/fam_cis_direct.cpp
+++ b/src/cis/fam_cis_direct.cpp
@@ -729,6 +729,13 @@ void Fam_CIS_Direct::resize_region(uint64_t regionId, size_t nbytes,
         }
         throw e;
     }
+
+    if(region.allocationPolicy == SINGLE_NODE_SINGLE_ALLOC) {
+        message << "Region resize not permitted for SINGLE_NODE_SINGLE_ALLOC allocation policy";
+        THROW_ERRNO_MSG(CIS_Exception, REGION_RESIZE_NOT_PERMITTED,
+                        message.str().c_str());
+    }
+    
     used_memsrv_cnt = region.used_memsrv_cnt;
     std::list<std::shared_future<void> > resultList;
     size_t bytes_per_server = nbytes / used_memsrv_cnt;

--- a/src/cis/fam_cis_direct.h
+++ b/src/cis/fam_cis_direct.h
@@ -152,7 +152,6 @@ class Fam_CIS_Direct : public Fam_CIS {
 
     void acquire_CAS_lock(uint64_t offset, uint64_t memoryServerId);
     void release_CAS_lock(uint64_t offset, uint64_t memoryServerId);
-    uint64_t get_dataitem_id(uint64_t offset, uint64_t memoryServerId);
     size_t get_addr_size(uint64_t memoryServerId);
     void get_addr(void *memServerFabricAddr, uint64_t memoryServerId);
 

--- a/src/cis/fam_cis_rpc.proto
+++ b/src/cis/fam_cis_rpc.proto
@@ -164,7 +164,9 @@ message Fam_Region_Request {
     uint32 memorytype = 10;
     uint32 interleaveenable = 11;
     uint32 permissionlevel = 12;
-    repeated uint64 memsrv_list = 13;
+    uint32 allocpolicy = 13;
+    uint32 hostingnode = 14;
+    repeated uint64 memsrv_list = 15;
 }
 
 /*
@@ -190,13 +192,14 @@ message Fam_Region_Response {
     uint32 gid = 15;
     repeated uint64 memsrv_list = 16;
     uint32 permissionlevel = 17;
+    uint32 allocpolicy = 18;
     message Region_Key_Map {
         uint64 memserver_id = 1;
         repeated uint64 region_keys = 2;
         repeated uint64 region_base = 3;
     }
-    repeated Region_Key_Map region_key_map = 18;
-    bool region_registration_status = 19;
+    repeated Region_Key_Map region_key_map = 19;
+    bool region_registration_status = 20;
 }
 
 /*

--- a/src/cis/fam_cis_server.cpp
+++ b/src/cis/fam_cis_server.cpp
@@ -179,6 +179,9 @@ Fam_CIS_Server::create_region(::grpc::ServerContext *context,
         (Fam_Interleave_Enable)request->interleaveenable();
     regionAttributes->permissionLevel =
         (Fam_Permission_Level)request->permissionlevel();
+    regionAttributes->allocationPolicy =
+        (Fam_Allocation_Policy)request->allocpolicy();
+    regionAttributes->hostingNode = request->hostingnode();
     try {
         info = famCIS->create_region(request->name(), (size_t)request->size(),
                                      (mode_t)request->perm(), regionAttributes,
@@ -377,6 +380,7 @@ Fam_CIS_Server::lookup_region(::grpc::ServerContext *context,
     response->set_memorytype(info.memoryType);
     response->set_interleaveenable(info.interleaveEnable);
     response->set_permissionlevel(info.permissionLevel);
+    response->set_allocpolicy(info.allocationPolicy);
     CIS_SERVER_PROFILE_END_OPS(lookup_region);
     return ::grpc::Status::OK;
 }
@@ -444,6 +448,7 @@ Fam_CIS_Server::lookup_region(::grpc::ServerContext *context,
     response->set_interleaveenable(info.interleaveEnable);
     response->set_interleavesize(info.interleaveSize);
     response->set_permissionlevel(info.permissionLevel);
+    response->set_allocpolicy(info.allocationPolicy);
     for (uint64_t i = 0; i < info.used_memsrv_cnt; i++) {
         response->add_memsrv_list(info.memoryServerIds[i]);
     }

--- a/src/cis/fam_cis_thallium_client.cpp
+++ b/src/cis/fam_cis_thallium_client.cpp
@@ -197,6 +197,8 @@ Fam_Region_Item_Info Fam_CIS_Thallium_Client::create_region(
     cisRequest.set_memorytype(regionAttributes->memoryType);
     cisRequest.set_interleaveenable(regionAttributes->interleaveEnable);
     cisRequest.set_permissionlevel(regionAttributes->permissionLevel);
+    cisRequest.set_allocpolicy(regionAttributes->allocationPolicy);
+    cisRequest.set_hostingnode(regionAttributes->hostingNode);
     cisRequest.set_uid(uid);
     cisRequest.set_gid(gid);
 
@@ -369,6 +371,7 @@ Fam_Region_Item_Info Fam_CIS_Thallium_Client::lookup_region(string name,
         (Fam_Interleave_Enable)cisResponse.get_interleaveenable();
     info.permissionLevel =
         (Fam_Permission_Level)cisResponse.get_permissionlevel();
+    info.allocationPolicy = (Fam_Allocation_Policy)cisResponse.get_allocpolicy();
     return info;
 }
 
@@ -433,6 +436,7 @@ Fam_Region_Item_Info Fam_CIS_Thallium_Client::check_permission_get_region_info(
     info.interleaveSize = cisResponse.get_interleavesize();
     info.permissionLevel =
         (Fam_Permission_Level)cisResponse.get_permissionlevel();
+    info.allocationPolicy = (Fam_Allocation_Policy)cisResponse.get_allocpolicy();
     info.used_memsrv_cnt = cisResponse.get_memsrv_list().size();
     for (uint64_t i = 0; i < info.used_memsrv_cnt; i++) {
         info.memoryServerIds[i] = cisResponse.get_memsrv_list()[(int)i];

--- a/src/cis/fam_cis_thallium_rpc_structures.h
+++ b/src/cis/fam_cis_thallium_rpc_structures.h
@@ -103,6 +103,8 @@ class Fam_CIS_Thallium_Request {
     uint64_t nbytes;
     uint64_t src_used_memsrv_cnt;
     std::vector<uint64_t> memsrv_list;
+    uint32_t allocpolicy;
+    uint32_t hostingnode;
 
   public:
     Fam_CIS_Thallium_Request() {}
@@ -155,6 +157,8 @@ class Fam_CIS_Thallium_Request {
     DECL_GETTER_SETTER(nbytes)
     DECL_GETTER_SETTER(src_used_memsrv_cnt)
     DECL_VECTOR_GETTER_SETTER(memsrv_list)
+    DECL_GETTER_SETTER(allocpolicy)
+    DECL_GETTER_SETTER(hostingnode)
 
     template <typename A>
     friend void serialize(A &ar, Fam_CIS_Thallium_Request &m) {
@@ -206,6 +210,8 @@ class Fam_CIS_Thallium_Request {
         ar &m.nbytes;
         ar &m.src_used_memsrv_cnt;
         ar &m.memsrv_list;
+        ar &m.allocpolicy;
+        ar &m.hostingnode;
     }
 };
 
@@ -248,6 +254,7 @@ class Fam_CIS_Thallium_Response {
     string diname;
     string contents;
     bool status;
+    uint32_t allocpolicy;
 
   public:
     Fam_CIS_Thallium_Response() {}
@@ -308,6 +315,7 @@ class Fam_CIS_Thallium_Response {
     DECL_GETTER_SETTER(diname)
     DECL_GETTER_SETTER(contents)
     DECL_GETTER_SETTER(status)
+    DECL_GETTER_SETTER(allocpolicy)
 
     template <typename A>
     friend void serialize(A &ar, Fam_CIS_Thallium_Response &p) {
@@ -349,6 +357,7 @@ class Fam_CIS_Thallium_Response {
         ar &p.diname;
         ar &p.contents;
         ar &p.status;
+        ar &p.allocpolicy;
     }
 };
 #endif

--- a/src/cis/fam_cis_thallium_server.cpp
+++ b/src/cis/fam_cis_thallium_server.cpp
@@ -219,6 +219,8 @@ void Fam_CIS_Thallium_Server::create_region(
         (Fam_Interleave_Enable)cisRequest.get_interleaveenable();
     regionAttributes->permissionLevel =
         (Fam_Permission_Level)cisRequest.get_permissionlevel();
+    regionAttributes->allocationPolicy = (Fam_Allocation_Policy)cisRequest.get_allocpolicy();
+    regionAttributes->hostingNode = cisRequest.get_hostingnode();
     try {
         info = direct_CIS->create_region(
             cisRequest.get_name(), (size_t)cisRequest.get_size(),
@@ -392,6 +394,7 @@ void Fam_CIS_Thallium_Server::lookup_region(
         cisResponse.set_memorytype(info.memoryType);
         cisResponse.set_interleaveenable(info.interleaveEnable);
         cisResponse.set_permissionlevel(info.permissionLevel);
+	cisResponse.set_allocpolicy(info.allocationPolicy);
         cisResponse.set_status(ok);
     } catch (Fam_Exception &e) {
         cisResponse.set_errorcode(e.fam_error());
@@ -453,6 +456,7 @@ void Fam_CIS_Thallium_Server::check_permission_get_region_info(
         cisResponse.set_interleaveenable(info.interleaveEnable);
         cisResponse.set_interleavesize(info.interleaveSize);
         cisResponse.set_permissionlevel(info.permissionLevel);
+	cisResponse.set_allocpolicy(info.allocationPolicy);
         cisResponse.set_memsrv_list(info.memoryServerIds,
                                     (int)info.used_memsrv_cnt);
         cisResponse.set_status(ok);

--- a/src/common/fam_internal.h
+++ b/src/common/fam_internal.h
@@ -42,7 +42,7 @@
  *
  * Work in progress, UNSTABLE
  * Uses _Generic and 128-bit integer types, tested under gcc 6.3.0. May require
- * “-std=c11” compiler flag if you are using the generic API as documented in
+ * ï¿½-std=c11ï¿½ compiler flag if you are using the generic API as documented in
  * OpenFAM-API-v104.
  *
  * Programming conventions used in the API:
@@ -130,6 +130,10 @@ namespace openfam {
 #define RPC_PROTOCOL_TCP "ofi+tcp://"
 
 #define ADDR_SIZE 20
+
+#define MIN_OBJ_SIZE 128
+
+#define SINGLE_ALLOC_OFFSET 65536 
 
 #define FAM_UNIMPLEMENTED_MEMSRVMODEL()                                        \
     {                                                                          \
@@ -339,6 +343,7 @@ typedef struct {
     size_t maxNameLen;
     uint64_t interleaveSize;
     Fam_Permission_Level permissionLevel;
+    Fam_Allocation_Policy allocationPolicy;
     Fam_Region_Memory_Map regionMemoryMap;
     bool itemRegistrationStatus;
 } Fam_Region_Item_Info;
@@ -435,6 +440,13 @@ inline string protocol_map(string provider) {
         break;
     }
     return protocol;
+}
+
+inline uint64_t get_dataitem_id(uint64_t offset,
+                                         uint64_t memoryServerId) {
+    uint64_t dataitemId = memoryServerId << 48;
+    dataitemId |= offset / MIN_OBJ_SIZE;
+    return dataitemId;
 }
 
 } // namespace openfam

--- a/src/fam-api/fam_descriptor.cpp
+++ b/src/fam-api/fam_descriptor.cpp
@@ -424,6 +424,10 @@ class Fam_Region_Descriptor::FamRegionDescriptorImpl_ {
         permissionLevel = reg_permissionLevel;
     }
 
+    void set_allocationPolicy(Fam_Allocation_Policy reg_allocationPolicy) {
+        allocationPolicy = reg_allocationPolicy;
+    }
+
     Fam_Redundancy_Level get_redundancyLevel() { return redundancyLevel; }
 
     Fam_Memory_Type get_memoryType() { return memoryType; }
@@ -431,6 +435,8 @@ class Fam_Region_Descriptor::FamRegionDescriptorImpl_ {
     Fam_Interleave_Enable get_interleaveEnable() { return interleaveEnable; }
 
     Fam_Permission_Level get_permissionLevel() { return permissionLevel; }
+
+    Fam_Allocation_Policy get_allocationPolicy() { return allocationPolicy; }
 
   private:
     Fam_Global_Descriptor gDescriptor;
@@ -443,6 +449,7 @@ class Fam_Region_Descriptor::FamRegionDescriptorImpl_ {
     Fam_Memory_Type memoryType;
     Fam_Interleave_Enable interleaveEnable;
     Fam_Permission_Level permissionLevel;
+    Fam_Allocation_Policy allocationPolicy;
 };
 
 Fam_Region_Descriptor::Fam_Region_Descriptor(Fam_Global_Descriptor gDescriptor,
@@ -517,6 +524,11 @@ void Fam_Region_Descriptor::set_permissionLevel(
     frdimpl_->set_permissionLevel(permissionLevel);
 }
 
+void Fam_Region_Descriptor::set_allocationPolicy(
+    Fam_Allocation_Policy allocationPolicy) {
+    frdimpl_->set_allocationPolicy(allocationPolicy);
+}
+
 Fam_Redundancy_Level Fam_Region_Descriptor::get_redundancyLevel() {
     return frdimpl_->get_redundancyLevel();
 }
@@ -529,4 +541,8 @@ Fam_Interleave_Enable Fam_Region_Descriptor::get_interleaveEnable() {
 
 Fam_Permission_Level Fam_Region_Descriptor::get_permissionLevel() {
     return frdimpl_->get_permissionLevel();
+}
+
+Fam_Allocation_Policy Fam_Region_Descriptor::get_allocationPolicy() {
+    return frdimpl_->get_allocationPolicy();
 }

--- a/src/metadata_service/fam_metadata_rpc.proto
+++ b/src/metadata_service/fam_metadata_rpc.proto
@@ -113,7 +113,9 @@ message Fam_Metadata_Region_Request {
     uint32 memorytype = 18;
     uint32 interleaveenable = 19;
     uint64 interleavesize = 20;
-    uint64 permission_level = 21;
+    uint32 permission_level = 21;
+    uint32 allocpolicy = 22; 
+    uint32 hostingnode = 23;
 }
 
 message Fam_Metadata_Region_Response {
@@ -135,7 +137,8 @@ message Fam_Metadata_Region_Response {
     uint32 memorytype = 16;
     uint32 interleaveenable = 17;
     uint64 interleavesize = 18;
-    uint64 permission_level = 19;
+    uint32 permission_level = 19;
+    uint32 allocpolicy = 20;
 }
 /*
  * Response message used by methods signal_start and signal_termination
@@ -172,6 +175,8 @@ message Fam_Metadata_Request {
     repeated uint64 memsrv_list = 20;
     uint64 memsrv_cnt = 21;
     uint64 permission_level = 22;
+    uint32 allocpolicy = 23; 
+    uint32 hostingnode = 24;
 }
 
 message Fam_Metadata_Response {

--- a/src/metadata_service/fam_metadata_service.h
+++ b/src/metadata_service/fam_metadata_service.h
@@ -108,6 +108,7 @@ typedef struct {
     bool isHeapCreated;
     Fam_Redundancy_Level redundancyLevel;
     Fam_Permission_Level permissionLevel;
+    Fam_Allocation_Policy allocationPolicy;
     Fam_Memory_Type memoryType;
     Fam_Interleave_Enable interleaveEnable;
     size_t interleaveSize;

--- a/src/metadata_service/fam_metadata_service_client.cpp
+++ b/src/metadata_service/fam_metadata_service_client.cpp
@@ -171,6 +171,7 @@ void Fam_Metadata_Service_Client::metadata_insert_region(
     req.set_memorytype(region->memoryType);
     req.set_interleaveenable(region->interleaveEnable);
     req.set_permission_level(region->permissionLevel);
+    req.set_allocpolicy(region->allocationPolicy);  
     req.set_memsrv_cnt(region->used_memsrv_cnt);
     for (int i = 0; i < (int)region->used_memsrv_cnt; i++) {
         req.add_memsrv_list(region->memServerIds[i]);
@@ -234,6 +235,7 @@ bool Fam_Metadata_Service_Client::metadata_find_region(
         region.interleaveEnable = (Fam_Interleave_Enable)res.interleaveenable();
         region.interleaveSize = res.interleavesize();
         region.permissionLevel = (Fam_Permission_Level)res.permission_level();
+        region.allocationPolicy = (Fam_Allocation_Policy)res.allocpolicy();
         for (int i = 0; i < (int)region.used_memsrv_cnt; i++) {
             region.memServerIds[i] = res.memsrv_list(i);
         }
@@ -267,6 +269,7 @@ bool Fam_Metadata_Service_Client::metadata_find_region(
         region.interleaveEnable = (Fam_Interleave_Enable)res.interleaveenable();
         region.interleaveSize = res.interleavesize();
         region.permissionLevel = (Fam_Permission_Level)res.permission_level();
+        region.allocationPolicy = (Fam_Allocation_Policy)res.allocpolicy();
         for (int i = 0; i < (int)region.used_memsrv_cnt; i++) {
             region.memServerIds[i] = res.memsrv_list(i);
         }
@@ -295,6 +298,7 @@ void Fam_Metadata_Service_Client::metadata_modify_region(
     req.set_interleaveenable(region->interleaveEnable);
     req.set_interleavesize(region->interleaveSize);
     req.set_permission_level(region->permissionLevel);
+    req.set_allocpolicy(region->allocationPolicy);
     req.set_memsrv_cnt(region->used_memsrv_cnt);
     for (int i = 0; i < (int)region->used_memsrv_cnt; i++) {
         req.add_memsrv_list(region->memServerIds[i]);
@@ -325,6 +329,7 @@ void Fam_Metadata_Service_Client::metadata_modify_region(
     req.set_interleaveenable(region->interleaveEnable);
     req.set_interleavesize(region->interleaveSize);
     req.set_permission_level(region->permissionLevel);
+    req.set_allocpolicy(region->allocationPolicy);
     req.set_memsrv_cnt(region->used_memsrv_cnt);
     for (int i = 0; i < (int)region->used_memsrv_cnt; i++) {
         req.add_memsrv_list(region->memServerIds[i]);
@@ -818,7 +823,8 @@ void Fam_Metadata_Service_Client::metadata_validate_and_create_region(
     req.set_memorytype(regionAttributes->memoryType);
     req.set_interleaveenable(regionAttributes->interleaveEnable);
     req.set_permission_level(regionAttributes->permissionLevel);
-
+    req.set_allocpolicy(regionAttributes->allocationPolicy);
+    req.set_hostingnode(regionAttributes->hostingNode);
     ::grpc::Status status =
         stub->metadata_validate_and_create_region(&ctx, req, &res);
     STATUS_CHECK(Metadata_Service_Exception)
@@ -884,6 +890,7 @@ void Fam_Metadata_Service_Client::metadata_find_region_and_check_permissions(
     region.interleaveEnable = (Fam_Interleave_Enable)res.interleaveenable();
     region.interleaveSize = res.interleavesize();
     region.permissionLevel = (Fam_Permission_Level)res.permission_level();
+    region.allocationPolicy = (Fam_Allocation_Policy)res.allocpolicy();
     for (int i = 0; i < (int)region.used_memsrv_cnt; i++) {
         region.memServerIds[i] = res.memsrv_list(i);
     }
@@ -920,6 +927,7 @@ void Fam_Metadata_Service_Client::metadata_find_region_and_check_permissions(
     region.interleaveEnable = (Fam_Interleave_Enable)res.interleaveenable();
     region.interleaveSize = res.interleavesize();
     region.permissionLevel = (Fam_Permission_Level)res.permission_level();
+    region.allocationPolicy = (Fam_Allocation_Policy)res.allocpolicy();
     for (int i = 0; i < (int)region.used_memsrv_cnt; i++) {
         region.memServerIds[i] = res.memsrv_list(i);
     }

--- a/src/metadata_service/fam_metadata_service_direct.cpp
+++ b/src/metadata_service/fam_metadata_service_direct.cpp
@@ -853,7 +853,6 @@ void Fam_Metadata_Service_Direct::Impl_::metadata_insert_region(
 	    dataitem.memoryServerIds[0] = region->memServerIds[0];
 	    uint64_t dataitemId = get_dataitem_id(dataitem.offsets[0], dataitem.memoryServerIds[0]);
 	    string nameStr(region->name);
-	    cout << "memserver node : " << dataitem.memoryServerIds[0] << " offset : "<< dataitem.offsets[0] << endl;
 	    metadata_insert_dataitem(dataitemId, region->regionId, &dataitem, nameStr);
     }
 }

--- a/src/metadata_service/fam_metadata_service_server.cpp
+++ b/src/metadata_service/fam_metadata_service_server.cpp
@@ -177,7 +177,7 @@ void Fam_Metadata_Service_Server::run() {
     region->interleaveEnable =
         (Fam_Interleave_Enable)request->interleaveenable();
     region->permissionLevel = (Fam_Permission_Level)request->permission_level();
-
+    region->allocationPolicy = (Fam_Allocation_Policy)request->allocpolicy();
     for (int ndx = 0; ndx < (int)region->used_memsrv_cnt; ndx++) {
         region->memServerIds[ndx] = request->memsrv_list(ndx);
     }
@@ -246,6 +246,7 @@ void Fam_Metadata_Service_Server::run() {
         response->set_interleaveenable(region.redundancyLevel);
         response->set_interleavesize(region.interleaveSize);
         response->set_permission_level(region.permissionLevel);
+        response->set_allocpolicy(region.allocationPolicy);
         for (int id = 0; id < (int)region.used_memsrv_cnt; ++id) {
             response->add_memsrv_list(region.memServerIds[id]);
         }
@@ -275,7 +276,7 @@ void Fam_Metadata_Service_Server::run() {
         (Fam_Interleave_Enable)request->interleaveenable();
     region->interleaveSize = request->interleavesize();
     region->permissionLevel = (Fam_Permission_Level)request->permission_level();
-
+    region->allocationPolicy = (Fam_Allocation_Policy)request->allocpolicy();
     for (int ndx = 0; ndx < (int)region->used_memsrv_cnt; ndx++) {
         region->memServerIds[ndx] = request->memsrv_list(ndx);
     }
@@ -571,6 +572,9 @@ void Fam_Metadata_Service_Server::run() {
         (Fam_Interleave_Enable)request->interleaveenable();
     regionAttributes->permissionLevel =
         (Fam_Permission_Level)request->permission_level();
+    regionAttributes->allocationPolicy =
+        (Fam_Allocation_Policy)request->allocpolicy();
+    regionAttributes->hostingNode = request->hostingnode();
 
     uint64_t regionId;
     try {
@@ -717,6 +721,7 @@ Fam_Metadata_Service_Server::metadata_find_region_and_check_permissions(
     response->set_interleaveenable(region.redundancyLevel);
     response->set_interleavesize(region.interleaveSize);
     response->set_permission_level(region.permissionLevel);
+    response->set_allocpolicy(region.allocationPolicy);
     for (int id = 0; id < (int)region.used_memsrv_cnt; ++id) {
         response->add_memsrv_list(region.memServerIds[id]);
     }

--- a/src/metadata_service/fam_metadata_service_thallium_client.cpp
+++ b/src/metadata_service/fam_metadata_service_thallium_client.cpp
@@ -232,6 +232,7 @@ void Fam_Metadata_Service_Thallium_Client::metadata_insert_region(
     metaRequest.set_memorytype(region->memoryType);
     metaRequest.set_interleaveenable(region->interleaveEnable);
     metaRequest.set_permission_level(region->permissionLevel);
+    metaRequest.set_allocpolicy(region->allocationPolicy);
     metaRequest.set_memsrv_cnt(region->used_memsrv_cnt);
     metaRequest.set_memsrv_list(region->memServerIds,
                                 (int)region->used_memsrv_cnt);
@@ -302,6 +303,8 @@ bool Fam_Metadata_Service_Thallium_Client::metadata_find_region(
         region.interleaveSize = metaResponse.get_interleavesize();
         region.permissionLevel =
             (Fam_Permission_Level)metaResponse.get_permission_level();
+        region.allocationPolicy =
+            (Fam_Allocation_Policy)metaResponse.get_allocpolicy();
         for (int i = 0; i < (int)region.used_memsrv_cnt; i++) {
             region.memServerIds[i] = metaResponse.get_memsrv_list()[i];
         }
@@ -340,6 +343,7 @@ bool Fam_Metadata_Service_Thallium_Client::metadata_find_region(
         region.interleaveSize = metaResponse.get_interleavesize();
         region.permissionLevel =
             (Fam_Permission_Level)metaResponse.get_permission_level();
+        region.allocationPolicy = (Fam_Allocation_Policy)metaResponse.get_allocpolicy();
         for (int i = 0; i < (int)region.used_memsrv_cnt; i++) {
             region.memServerIds[i] = metaResponse.get_memsrv_list()[i];
         }
@@ -367,6 +371,7 @@ void Fam_Metadata_Service_Thallium_Client::metadata_modify_region(
     metaRequest.set_interleaveenable(region->interleaveEnable);
     metaRequest.set_interleavesize(region->interleaveSize);
     metaRequest.set_permission_level(region->permissionLevel);
+    metaRequest.set_allocpolicy(region->allocationPolicy);
     metaRequest.set_memsrv_cnt(region->used_memsrv_cnt);
     metaRequest.set_memsrv_list(region->memServerIds,
                                 (int)region->used_memsrv_cnt);
@@ -397,6 +402,7 @@ void Fam_Metadata_Service_Thallium_Client::metadata_modify_region(
     metaRequest.set_interleaveenable(region->interleaveEnable);
     metaRequest.set_interleavesize(region->interleaveSize);
     metaRequest.set_permission_level(region->permissionLevel);
+    metaRequest.set_allocpolicy(region->allocationPolicy);
     metaRequest.set_memsrv_cnt(region->used_memsrv_cnt);
     metaRequest.set_memsrv_list(region->memServerIds,
                                 (int)region->used_memsrv_cnt);
@@ -901,6 +907,8 @@ void Fam_Metadata_Service_Thallium_Client::metadata_validate_and_create_region(
     metaRequest.set_memorytype(regionAttributes->memoryType);
     metaRequest.set_interleaveenable(regionAttributes->interleaveEnable);
     metaRequest.set_permission_level(regionAttributes->permissionLevel);
+    metaRequest.set_allocpolicy(regionAttributes->allocationPolicy);
+    metaRequest.set_hostingnode(regionAttributes->hostingNode); 
     Fam_Metadata_Thallium_Response metaResponse =
         rp_metadata_validate_and_create_region.on(ph)(metaRequest);
     RPC_STATUS_CHECK(Metadata_Service_Exception, metaResponse)
@@ -971,6 +979,7 @@ void Fam_Metadata_Service_Thallium_Client::
     region.interleaveSize = metaResponse.get_interleavesize();
     region.permissionLevel =
         (Fam_Permission_Level)metaResponse.get_permission_level();
+    region.allocationPolicy = (Fam_Allocation_Policy)metaResponse.get_allocpolicy();
     for (int i = 0; i < (int)region.used_memsrv_cnt; i++) {
         region.memServerIds[i] = metaResponse.get_memsrv_list()[i];
     }
@@ -1013,6 +1022,7 @@ void Fam_Metadata_Service_Thallium_Client::
     region.interleaveSize = metaResponse.get_interleavesize();
     region.permissionLevel =
         (Fam_Permission_Level)metaResponse.get_permission_level();
+    region.allocationPolicy = (Fam_Allocation_Policy)metaResponse.get_allocpolicy();
     for (int i = 0; i < (int)region.used_memsrv_cnt; i++) {
         region.memServerIds[i] = metaResponse.get_memsrv_list()[i];
     }

--- a/src/metadata_service/fam_metadata_service_thallium_rpc_structures.h
+++ b/src/metadata_service/fam_metadata_service_thallium_rpc_structures.h
@@ -85,6 +85,8 @@ class Fam_Metadata_Thallium_Request {
     bool check_name_id;
     uint64_t type_flag;
     uint64_t permission_level;
+    uint32_t allocpolicy;
+    uint32_t hostingnode;
 
   public:
     Fam_Metadata_Thallium_Request() {}
@@ -123,6 +125,8 @@ class Fam_Metadata_Thallium_Request {
     DECL_GETTER_SETTER(check_name_id)
     DECL_GETTER_SETTER(type_flag)
     DECL_GETTER_SETTER(permission_level)
+    DECL_GETTER_SETTER(allocpolicy)
+    DECL_GETTER_SETTER(hostingnode)
 
     template <typename A>
     friend void serialize(A &ar, Fam_Metadata_Thallium_Request &m) {
@@ -160,6 +164,8 @@ class Fam_Metadata_Thallium_Request {
         ar &m.check_name_id;
         ar &m.type_flag;
         ar &m.permission_level;
+        ar &m.allocpolicy;
+        ar &m.hostingnode;
     }
 };
 
@@ -188,6 +194,7 @@ class Fam_Metadata_Thallium_Response {
     uint64_t addrnamelen;
     uint64_t permission_level;
     uint64_t region_permission;
+    uint32_t allocpolicy;
 
   public:
     Fam_Metadata_Thallium_Response() {}
@@ -222,6 +229,7 @@ class Fam_Metadata_Thallium_Response {
     DECL_GETTER_SETTER(addrnamelen)
     DECL_GETTER_SETTER(permission_level)
     DECL_GETTER_SETTER(region_permission)
+    DECL_GETTER_SETTER(allocpolicy)
 
     template <typename A>
     friend void serialize(A &ar, Fam_Metadata_Thallium_Response &p) {
@@ -251,6 +259,7 @@ class Fam_Metadata_Thallium_Response {
         ar &p.addrnamelen;
         ar &p.permission_level;
         ar &p.region_permission;
+        ar &p.allocpolicy;
     }
 };
 #endif

--- a/src/metadata_service/fam_metadata_service_thallium_server.cpp
+++ b/src/metadata_service/fam_metadata_service_thallium_server.cpp
@@ -224,6 +224,7 @@ MEMSERVER_PROFILE_START(METADATA_THALLIUM_SERVER)
         region->used_memsrv_cnt = metaRequest.get_memsrv_cnt();
         region->redundancyLevel =
             (Fam_Redundancy_Level)metaRequest.get_redundancylevel();
+        region->allocationPolicy = (Fam_Allocation_Policy)metaRequest.get_allocpolicy();
         region->memoryType = (Fam_Memory_Type)metaRequest.get_memorytype();
         region->interleaveEnable =
             (Fam_Interleave_Enable)metaRequest.get_interleaveenable();
@@ -233,7 +234,7 @@ MEMSERVER_PROFILE_START(METADATA_THALLIUM_SERVER)
         for (int ndx = 0; ndx < (int)region->used_memsrv_cnt; ndx++) {
             region->memServerIds[ndx] = metaRequest.get_memsrv_list()[ndx];
         }
-
+	cout << "Allocation policy : " << region->allocationPolicy << endl;
         try {
             direct_metadataService->metadata_insert_region(
                 metaRequest.get_key_region_id(),
@@ -301,6 +302,7 @@ MEMSERVER_PROFILE_START(METADATA_THALLIUM_SERVER)
                 metaResponse.set_interleaveenable(region.redundancyLevel);
                 metaResponse.set_interleavesize(region.interleaveSize);
                 metaResponse.set_permission_level(region.permissionLevel);
+                metaResponse.set_allocpolicy(region.allocationPolicy);
                 metaResponse.set_memsrv_list(region.memServerIds,
                                              (int)region.used_memsrv_cnt);
             }
@@ -337,6 +339,8 @@ MEMSERVER_PROFILE_START(METADATA_THALLIUM_SERVER)
         region->interleaveSize = metaRequest.get_interleavesize();
         region->permissionLevel =
             (Fam_Permission_Level)metaRequest.get_permission_level();
+        region->allocationPolicy =
+            (Fam_Allocation_Policy)metaRequest.get_allocpolicy();
         for (int id = 0; id < (int)region->used_memsrv_cnt; ++id) {
             region->memServerIds[id] = metaRequest.get_memsrv_list()[id];
         }
@@ -658,7 +662,8 @@ MEMSERVER_PROFILE_START(METADATA_THALLIUM_SERVER)
             (Fam_Interleave_Enable)metaRequest.get_interleaveenable();
         regionAttributes->permissionLevel =
             (Fam_Permission_Level)metaRequest.get_permission_level();
-
+        regionAttributes->allocationPolicy = (Fam_Allocation_Policy)metaRequest.get_allocpolicy();
+        regionAttributes->hostingNode = metaRequest.get_hostingnode();        
         uint64_t regionId;
         try {
             direct_metadataService->metadata_validate_and_create_region(
@@ -825,6 +830,7 @@ MEMSERVER_PROFILE_START(METADATA_THALLIUM_SERVER)
             metaResponse.set_interleaveenable(region.redundancyLevel);
             metaResponse.set_interleavesize(region.interleaveSize);
             metaResponse.set_permission_level(region.permissionLevel);
+            metaResponse.set_allocpolicy(region.allocationPolicy);
             metaResponse.set_memsrv_list(region.memServerIds,
                                          (int)region.used_memsrv_cnt);
             metaResponse.set_status(ok);

--- a/src/metadata_service/fam_metadata_service_thallium_server.cpp
+++ b/src/metadata_service/fam_metadata_service_thallium_server.cpp
@@ -234,7 +234,6 @@ MEMSERVER_PROFILE_START(METADATA_THALLIUM_SERVER)
         for (int ndx = 0; ndx < (int)region->used_memsrv_cnt; ndx++) {
             region->memServerIds[ndx] = metaRequest.get_memsrv_list()[ndx];
         }
-	cout << "Allocation policy : " << region->allocationPolicy << endl;
         try {
             direct_metadataService->metadata_insert_region(
                 metaRequest.get_key_region_id(),


### PR DESCRIPTION
In this commit, a new field is added in the region attribute **allocationPolicy** so that user can chose an allocation policy within a region. Currently only 2 allocation policies are supported, **SINGLE_NODE_SINGLE_ALLOC** which means region is allocated in only one node which is specified using another region attribute called **hostingNode** and the entire region is allocated as one single dataitem. Another policy is **MULTI_NODE_MULTI_ALLOC**, this policy allows to have multiple allocations of data items in the region and the region can span across multiple nodes so as dataitems.