### PR TITLE
Set FAM_THREAD_MULTIPLE in fam_atomics_reg_test

### DIFF
--- a/test/reg-test/fam-api-reg/fam_atomics_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_atomics_reg_test.cpp
@@ -265,6 +265,7 @@ int main(int argc, char **argv) {
 
     init_fam_options(&fam_opts);
 
+    fam_opts.famThreadModel = strdup("FAM_THREAD_MULTIPLE");
     EXPECT_NO_THROW(my_fam->fam_initialize("default", &fam_opts));
 
     testRegionStr = get_uniq_str("test", my_fam);


### PR DESCRIPTION
    The test performs fam operations from multiple threads with
    no locking and without setting FAM_THREAD_MULTIPLE. The
    operations may be atomic, but there are no guarantees that
    about issues in the code path without this setting.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>