### PR TITLE
Async Thallium RPCs calling server twice

### DIFF
--- a/src/cis/fam_cis_thallium_client.cpp
+++ b/src/cis/fam_cis_thallium_client.cpp
@@ -546,8 +546,6 @@ void *Fam_CIS_Thallium_Client::copy(
     cisRequest.set_src_used_memsrv_cnt(srcUsedMemsrvCnt);
     cisRequest.set_src_keys(srcKeys, (int)srcUsedMemsrvCnt);
     cisRequest.set_src_base_addr(srcBaseAddrList, (int)srcUsedMemsrvCnt);
-    Fam_CIS_Thallium_Response cisResponse = rp_copy.on(ph)(cisRequest);
-    RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 
     auto my_async_response_ptr =
         new tl::async_response(rp_copy.on(ph).async(cisRequest));
@@ -563,7 +561,8 @@ void Fam_CIS_Thallium_Client::wait_for_copy(void *waitObj) {
         throw CIS_Exception(FAM_ERR_INVALID, "Copy waitObj is null");
     }
 
-    waitObjIn->wait();
+    Fam_CIS_Thallium_Response cisResponse = waitObjIn->wait();
+    RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 }
 
 void *Fam_CIS_Thallium_Client::backup(uint64_t srcRegionId, uint64_t srcOffset,
@@ -580,8 +579,6 @@ void *Fam_CIS_Thallium_Client::backup(uint64_t srcRegionId, uint64_t srcOffset,
     cisRequest.set_bname(BackupName);
     cisRequest.set_uid(uid);
     cisRequest.set_gid(gid);
-    Fam_CIS_Thallium_Response cisResponse = rp_backup.on(ph)(cisRequest);
-    RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 
     auto my_async_response_ptr =
         new tl::async_response(rp_backup.on(ph).async(cisRequest));
@@ -597,7 +594,8 @@ void Fam_CIS_Thallium_Client::wait_for_backup(void *waitObj) {
         throw CIS_Exception(FAM_ERR_INVALID, "Copy waitObj is null");
     }
 
-    waitObjIn->wait();
+    Fam_CIS_Thallium_Response cisResponse = waitObjIn->wait();
+    RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 }
 
 void *Fam_CIS_Thallium_Client::restore(uint64_t destRegionId,
@@ -614,8 +612,6 @@ void *Fam_CIS_Thallium_Client::restore(uint64_t destRegionId,
     cisRequest.set_bname(BackupName);
     cisRequest.set_uid(uid);
     cisRequest.set_gid(gid);
-    Fam_CIS_Thallium_Response cisResponse = rp_restore.on(ph)(cisRequest);
-    RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 
     auto my_async_response_ptr =
         new tl::async_response(rp_restore.on(ph).async(cisRequest));
@@ -631,7 +627,8 @@ void Fam_CIS_Thallium_Client::wait_for_restore(void *waitObj) {
         throw CIS_Exception(FAM_ERR_INVALID, "Copy waitObj is null");
     }
 
-    waitObjIn->wait();
+    Fam_CIS_Thallium_Response cisResponse = waitObjIn->wait();
+    RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 }
 
 string Fam_CIS_Thallium_Client::list_backup(string BackupName,
@@ -662,8 +659,6 @@ void *Fam_CIS_Thallium_Client::delete_backup(string BackupName,
     cisRequest.set_memserver_id(memoryServerId);
     cisRequest.set_uid(uid);
     cisRequest.set_gid(gid);
-    Fam_CIS_Thallium_Response cisResponse = rp_delete_backup.on(ph)(cisRequest);
-    RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 
     auto my_async_response_ptr =
         new tl::async_response(rp_delete_backup.on(ph).async(cisRequest));
@@ -678,7 +673,9 @@ void Fam_CIS_Thallium_Client::wait_for_delete_backup(void *waitObj) {
     if (!waitObjIn) {
         throw CIS_Exception(FAM_ERR_INVALID, "Copy waitObj is null");
     }
-    waitObjIn->wait();
+
+    Fam_CIS_Thallium_Response cisResponse = waitObjIn->wait();
+    RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 }
 
 Fam_Backup_Info

--- a/src/cis/fam_cis_thallium_client.cpp
+++ b/src/cis/fam_cis_thallium_client.cpp
@@ -562,6 +562,7 @@ void Fam_CIS_Thallium_Client::wait_for_copy(void *waitObj) {
     }
 
     Fam_CIS_Thallium_Response cisResponse = waitObjIn->wait();
+    delete waitObjIn;
     RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 }
 
@@ -595,6 +596,7 @@ void Fam_CIS_Thallium_Client::wait_for_backup(void *waitObj) {
     }
 
     Fam_CIS_Thallium_Response cisResponse = waitObjIn->wait();
+    delete waitObjIn;
     RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 }
 
@@ -628,6 +630,7 @@ void Fam_CIS_Thallium_Client::wait_for_restore(void *waitObj) {
     }
 
     Fam_CIS_Thallium_Response cisResponse = waitObjIn->wait();
+    delete waitObjIn;
     RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 }
 
@@ -675,6 +678,7 @@ void Fam_CIS_Thallium_Client::wait_for_delete_backup(void *waitObj) {
     }
 
     Fam_CIS_Thallium_Response cisResponse = waitObjIn->wait();
+    delete waitObjIn;
     RPC_STATUS_CHECK(CIS_Exception, cisResponse)
 }
 


### PR DESCRIPTION
    The Thallium client code for fam_copy(), fam_backup(),
    fam_restore(), and fam_delete_backup() have a common bug
    so that the server function is called once synchronously
    and then called again asynchronously.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>