### PR TITLE
Fixed usage of EXPECT_STREQ() in tests

### DIFF
--- a/test/maxconfig/fam-api-maxconfig/fam_put_get_quiet_nonblock_test_largeio.cpp
+++ b/test/maxconfig/fam-api-maxconfig/fam_put_get_quiet_nonblock_test_largeio.cpp
@@ -77,7 +77,7 @@ TEST(FamPutGetNonblock, PutGetNonblockSuccess) {
 
     EXPECT_NO_THROW(my_fam->fam_quiet());
 
-    EXPECT_STREQ(local, local2);
+    EXPECT_EQ(0, memcmp(local, local2, TEST_IO_SIZE));
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));

--- a/test/maxconfig/fam-api-maxconfig/fam_put_get_test_largeio.cpp
+++ b/test/maxconfig/fam-api-maxconfig/fam_put_get_test_largeio.cpp
@@ -70,7 +70,7 @@ TEST(FamPutGet, PutGetSuccess) {
     char *local2 = (char *)malloc(TEST_IO_SIZE);
     EXPECT_NO_THROW(my_fam->fam_get_blocking(local2, item, 0, TEST_IO_SIZE));
 
-    EXPECT_STREQ(local, local2);
+    EXPECT_EQ(0, memcmp(local, local2, TEST_IO_SIZE));
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));

--- a/test/reg-test/fam-api-reg/fam_copy_reg_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_copy_reg_test.cpp
@@ -410,8 +410,7 @@ TEST(FamCopy, CopySameSizeSuccess) {
     memset(local2, 'b', 128);
 
     EXPECT_NO_THROW(my_fam->fam_get_blocking(local2, destItem, 0, 128));
-    int stringCompareResult = strncmp(local, local2, 128);
-    EXPECT_EQ(stringCompareResult, 0);
+    EXPECT_EQ(0, memcmp(local, local2, 128));
     EXPECT_NO_THROW(my_fam->fam_deallocate(srcItem));
     EXPECT_NO_THROW(my_fam->fam_destroy_region(srcDesc));
 

--- a/test/reg-test/fam-api-reg/fam_dataitem_interleave_test.cpp
+++ b/test/reg-test/fam-api-reg/fam_dataitem_interleave_test.cpp
@@ -131,7 +131,7 @@ TEST(DataitemInterleaving, PutGetSuccess) {
     EXPECT_NO_THROW(
         my_fam->fam_get_blocking(local2, item, 8, 6 * INTERLEAVE_SIZE));
 
-    EXPECT_STREQ(local, local2);
+    EXPECT_EQ(0, memcmp(local, local2, 6 * INTERLEAVE_SIZE));
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
 
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
@@ -226,7 +226,7 @@ TEST(DataitemInterleaving, PutGetNonblockSuccess) {
 
     EXPECT_NO_THROW(my_fam->fam_quiet());
 
-    EXPECT_STREQ(local, local2);
+    EXPECT_EQ(0, memcmp(local, local2, 6 * INTERLEAVE_SIZE));
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
 
     EXPECT_NO_THROW(my_fam->fam_destroy_region(desc));
@@ -737,7 +737,7 @@ TEST(DataitemInterleaving, Copy) {
     for (int i = 0; i < ITERATION; i++) {
         EXPECT_NO_THROW(my_fam->fam_get_blocking(local2, destItem[i], 1024,
                                                  6 * INTERLEAVE_SIZE));
-        EXPECT_STREQ(local, local2);
+	EXPECT_EQ(0, memcmp(local, local2, 6 * INTERLEAVE_SIZE));
     }
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(srcItem));
@@ -936,7 +936,7 @@ TEST(DataitemInterleaving, RestoreSuccess) {
     EXPECT_NO_THROW(
         my_fam->fam_get_blocking(local2, item, 0, 6 * backupInterleaveSize));
 
-    EXPECT_STREQ(local, local2);
+    EXPECT_EQ(0, memcmp(local, local2, 6 * backupInterleaveSize));
     free(local2);
 
     EXPECT_NO_THROW(my_fam->fam_deallocate(item));
@@ -1027,7 +1027,7 @@ TEST(DataitemInterleaving, CreateDataitemRestoreSuccess) {
     char *local2 = (char *)malloc(6 * backupInterleaveSize);
     EXPECT_NO_THROW(
         my_fam->fam_get_blocking(local2, item, 0, 6 * backupInterleaveSize));
-    EXPECT_STREQ(local, local2);
+    EXPECT_EQ(0, memcmp(local, local2, 6 * backupInterleaveSize));
     free(local);
     free(local2);
 

--- a/test/reg-test/fam-api-reg/fam_region_registration_resize.cpp
+++ b/test/reg-test/fam-api-reg/fam_region_registration_resize.cpp
@@ -100,7 +100,7 @@ void *thr_func1(void *arg) {
         char *local2 = (char *)malloc(4294967296);
 
         EXPECT_NO_THROW(my_fam->fam_get_blocking(local2, item1, 0, 4294967296));
-        EXPECT_STREQ(local, local2);
+	EXPECT_EQ(0, memcmp(local, local2, 4294967296));
 
         // Resize the region
         EXPECT_NO_THROW(my_fam->fam_resize_region(desc, 17179869184));
@@ -141,7 +141,7 @@ void *thr_func1(void *arg) {
         char *local3 = (char *)malloc(4294967296);
 
         EXPECT_NO_THROW(my_fam->fam_get_blocking(local3, item2, 0, 4294967296));
-        EXPECT_STREQ(local, local3);
+        EXPECT_EQ(0, memcmp(local, local3, 4294967296));
 
         // Resize the region second time
         EXPECT_NO_THROW(my_fam->fam_resize_region(desc, 34359738368));
@@ -173,7 +173,7 @@ void *thr_func1(void *arg) {
         char *local3 = (char *)malloc(6442450944);
 
         EXPECT_NO_THROW(my_fam->fam_get_blocking(local3, item3, 0, 6442450944));
-        EXPECT_STREQ(local, local3);
+	EXPECT_EQ(0, memcmp(local, local3, 6442450944));
 
         free(local);
         free(local3);


### PR DESCRIPTION
In certain tests here, we are dealing with blocks of memory that are not null-terminated C-strings and so we should be using EXPECT_EQ() macro with a memory comparison function like memcmp() instead of the EXPECT_STREQ(). For instance, in place of EXPECT_STREQ(char_pointer1, char_pointer2), we use EXPECT_EQ(0, memcmp(char_pointer1, char_pointer2, size)) so as to ensure both pointer blocks are compared accurately.
The size parameter here ensures we specify the exact size of the memory blocks that needs to be compared and would prevent buffer overflows or incomplete comparisons issues.