### PR TITLE
Fixed duplicate local buffer registration from fam_context_open()

### DIFF
--- a/src/common/fam_context.cpp
+++ b/src/common/fam_context.cpp
@@ -83,14 +83,14 @@ Fam_Context::Fam_Context(struct fi_info *fi, struct fid_domain *domain,
     struct fi_cq_attr cq_attr;
     memset(&cq_attr, 0, sizeof(cq_attr));
     cq_attr.format = FI_CQ_FORMAT_DATA;
-    if((strncmp(fi->fabric_attr->prov_name, "cxi", 3) != 0)) {
-    	cq_attr.wait_obj = FI_WAIT_UNSPEC;
+    if ((strncmp(fi->fabric_attr->prov_name, "cxi", 3) != 0)) {
+        cq_attr.wait_obj = FI_WAIT_UNSPEC;
     }
     cq_attr.wait_cond = FI_CQ_COND_NONE;
 
     /* Set the cq size unless a default is in play. */
     if (!getenv("FI_CXI_DEFAULT_CQ_SIZE"))
-    	cq_attr.size = fi->tx_attr->size;
+        cq_attr.size = fi->tx_attr->size;
     ret = fi_cq_open(domain, &cq_attr, &txcq, &txcq);
     if (ret < 0) {
         message << "Fam libfabric fi_cq_open failed: " << fabric_strerror(ret);
@@ -199,6 +199,16 @@ void Fam_Context::register_heap(void *base, size_t len,
     }
     for (size_t i = 0; i < iov_limit; i++)
         mr_descs[i] = fi_mr_desc(mr);
+}
+
+void Fam_Context::register_existing_heap(Fam_Context *famCtx,
+                                         size_t iov_limit) {
+    local_buf_base = famCtx->local_buf_base;
+    local_buf_size = famCtx->local_buf_size;
+    mr_descs = (void **)calloc(iov_limit, sizeof(*mr_descs));
+    for (size_t i = 0; i < iov_limit; i++)
+        mr_descs[i] = famCtx->mr_descs[i];
+    mr = NULL;
 }
 
 } // namespace openfam

--- a/src/common/fam_context.h
+++ b/src/common/fam_context.h
@@ -121,6 +121,7 @@ class Fam_Context {
     }
     void register_heap(void *base, size_t len, struct fid_domain *domain,
                        size_t iov_limit);
+    void register_existing_heap(Fam_Context *famCtx, size_t iov_limit);
     void **get_mr_descs(const void *local_addr, size_t local_size) {
         if (local_buf_size != 0 &&
             (char *)local_addr >= (char *)local_buf_base &&

--- a/src/common/fam_ops_libfabric.h
+++ b/src/common/fam_ops_libfabric.h
@@ -410,6 +410,7 @@ class Fam_Ops_Libfabric : public Fam_Ops {
     size_t get_fabric_iov_limit() { return fabric_iov_limit; }
     size_t get_fabric_max_msg_size() { return fabric_max_msg_size; }
     void register_heap(void *base, size_t len);
+    void register_existing_heap(Fam_Ops_Libfabric *famOpsObj);
 
   protected:
     // Server_Map name;

--- a/src/fam-api/fam_ops_libfabric.cpp
+++ b/src/fam-api/fam_ops_libfabric.cpp
@@ -30,13 +30,13 @@
  */
 
 #include <arpa/inet.h>
+#include <future>
 #include <iostream>
 #include <sstream>
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <future>
 
 #include "common/fam_internal.h"
 #include "common/fam_libfabric.h"
@@ -242,7 +242,8 @@ int Fam_Ops_Libfabric::initialize() {
     if (fi->ep_attr->max_msg_size > 0) {
         fabric_max_msg_size = fi->ep_attr->max_msg_size;
     } else {
-        message << "Unexpected FAM libfabric error: Fabric Info max message size 0";
+        message
+            << "Unexpected FAM libfabric error: Fabric Info max message size 0";
         THROW_ERR_MSG(Fam_Datapath_Exception, message.str().c_str());
     }
 
@@ -5402,4 +5403,10 @@ void Fam_Ops_Libfabric::context_close(uint64_t contextId) {
 void Fam_Ops_Libfabric::register_heap(void *base, size_t len) {
     get_context()->register_heap(base, len, domain, fabric_iov_limit);
 }
+
+void Fam_Ops_Libfabric::register_existing_heap(Fam_Ops_Libfabric *famOpsObj) {
+    get_context()->register_existing_heap(famOpsObj->get_context(),
+                                          fabric_iov_limit);
+}
+
 } // namespace openfam

--- a/test/unit-test/fam-api/fam_options_test.cpp
+++ b/test/unit-test/fam-api/fam_options_test.cpp
@@ -1,8 +1,9 @@
 /*
  * fam_options_test.cpp
- * Copyright (c) 2019,2023 Hewlett Packard Enterprise Development, LP. All rights
- * reserved. Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Copyright (c) 2019,2023 Hewlett Packard Enterprise Development, LP. All
+ * rights reserved. Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
  * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
@@ -48,10 +49,9 @@ int main() {
     init_fam_options(&fam_opts);
     fam_opts.grpcPort = strdup("9500");
     fam_opts.runtime = strdup("NONE");
-    int *gBuf = (int *) malloc(sizeof(int));
+    int *gBuf = (int *)malloc(sizeof(int));
     fam_opts.local_buf_addr = gBuf;
     fam_opts.local_buf_size = sizeof(int);
-
 
     try {
         // Throws grpc exception because of wrong grpc port.
@@ -77,7 +77,7 @@ int main() {
     while (optList[i]) {
         char *opt = strdup(optList[i]);
         if (strncmp(opt, "PE", 2) == 0) {
-            try{
+            try {
                 int *optIntValue = (int *)my_fam->fam_get_option(opt);
                 cout << optList[i] << ":" << *optIntValue << endl;
                 free(optIntValue);
@@ -87,7 +87,7 @@ int main() {
                 cout << "Error: " << e.fam_error() << endl;
             }
         } else if (strncmp(opt, "LOC_BUF_SIZE", 12) == 0) {
-            try{
+            try {
                 size_t *optIntValue = (size_t *)my_fam->fam_get_option(opt);
                 cout << optList[i] << ":" << *optIntValue << endl;
                 free(optIntValue);
@@ -97,7 +97,7 @@ int main() {
                 cout << "Error: " << e.fam_error() << endl;
             }
         } else {
-            try{
+            try {
                 char *optValue = (char *)my_fam->fam_get_option(opt);
                 cout << optList[i] << ":" << optValue << endl;
                 free(optValue);
@@ -123,6 +123,23 @@ int main() {
 
     free(optList);
 
-    my_fam->fam_finalize("default");
-    cout << "fam finalize successful" << endl;
+    // Test fam_context_open/close after local buffer registrations
+    try {
+        fam_context *ctx = my_fam->fam_context_open();
+        ctx->fam_quiet();
+        my_fam->fam_context_close(ctx);
+    } catch (Fam_Exception &e) {
+        cout << "Exception caught" << endl;
+        cout << "Error msg: " << e.fam_error_msg() << endl;
+        cout << "Error: " << e.fam_error() << endl;
+    }
+
+    try {
+        my_fam->fam_finalize("default");
+        cout << "fam finalize successful" << endl;
+    } catch (Fam_Exception &e) {
+        cout << "Exception caught" << endl;
+        cout << "Error msg: " << e.fam_error_msg() << endl;
+        cout << "Error: " << e.fam_error() << endl;
+    }
 }


### PR DESCRIPTION
Duplicate local buffer registration has been observed when fam_context_open() is called after a local buffer gets registered through fam_initialize(). This results in an error exception from fi_mr_reg() in register_heap() and double-closing a mr descriptor when fam_finalize() is called after fam_context_close().

To resolve this issue, in this commit, I have added a new function, register_existing_heap(), which copies the existing mr descriptors in the default context to the new Fam_Context and used it instead of the register_heap() function if there is a local buffer that is already registered by the default context.

To check the errors, this commit is also providing a test case added in `test/unit-test/fam-api/fam_options_test.cpp`. Here is the more detailed error information including gdb backtrace after running the test case.

```
...
...
FAM_DEFAULT_MEMORY_TYPE:
IF_DEVICE:ibs1
LOC_BUF_ADDR:0x55555557c290
LOC_BUF_SIZE:4
Exception caught
Error msg: fam_get_option:1255:Fam Option not supported: badOption
Error: 4
[New Thread 0x7fffe13fc700 (LWP 137219)]
Exception caught
Error msg: register_heap:194:Fam libfabric fi_mr_reg failed: Unknown error -266
Error: 5
[Thread 0x7fffecbfb700 (LWP 137218) exited]
[New Thread 0x7fffecbfb700 (LWP 137220)]
free(): double free detected in tcache 2

Thread 1 "fam_options_tes" received signal SIGABRT, Aborted. 
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff791e859 in __GI_abort () at abort.c:79
#2  0x00007ffff798926e in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7ffff7ab3298 "%s\n")
    at ../sysdeps/posix/libc_fatal.c:155
#3  0x00007ffff79912fc in malloc_printerr (str=str@entry=0x7ffff7ab55d0 "free(): double free detected in tcache 2")
    at malloc.c:5347
#4  0x00007ffff7992f6d in _int_free (av=0x7ffff7ae8b80 <main_arena>, p=0x55555569c8a0, have_lock=0) at malloc.c:4201
#5  0x00007ffff787530c in rxm_mr_close () from /home/leesek/projects/OpenFAM/third-party/build//lib/libfabric.so.1
#6  0x00007ffff7ec6a59 in fi_close (fid=<optimized out>)
    at /home/leesek/projects/OpenFAM/third-party/build/include/rdma/fabric.h:603
#7  openfam::Fam_Context::~Fam_Context (this=0x5555555b1360, __in_chrg=<optimized out>)
    at /home/leesek/projects/OpenFAM/src/common/fam_context.cpp:145
#8  0x00007ffff7e9c2f1 in openfam::Fam_Ops_Libfabric::finalize (this=0x5555555aaab0)
    at /home/leesek/projects/OpenFAM/src/fam-api/fam_ops_libfabric.cpp:364
#9  0x00007ffff7e7d5bf in openfam::fam::Impl_::fam_finalize (this=0x555555574580, groupName=<optimized out>)
    at /home/leesek/projects/OpenFAM/src/fam-api/fam.cpp:1188
#10 0x00007ffff7e7d5f0 in openfam::fam::fam_finalize (this=<optimized out>, groupName=<optimized out>)
    at /home/leesek/projects/OpenFAM/src/fam-api/fam.cpp:5436
#11 0x000055555555706a in main () at /home/leesek/projects/OpenFAM/test/unit-test/fam-api/fam_options_test.cpp:138
```