### PR TITLE
Added fam_set_option() method for dynamic client buffer registration

### DIFF
--- a/include/fam/fam.h
+++ b/include/fam/fam.h
@@ -70,6 +70,7 @@
 
 #include <stdint.h>   // needed for uint64_t etc.
 #include <sys/stat.h> // needed for mode_t
+#include <stddef.h>    // needed for size_t
 
 #ifdef __cplusplus
 namespace openfam {
@@ -200,12 +201,10 @@ typedef struct {
     char *fam_default_memory_type;
     /** Interface device used by the PE for communication */
     char *if_device;
-    /** Local buffer address to be registered via client */
-    void *local_buf_addr;
-    /** Local buffer size to be registered via client */
-    uint64_t local_buf_size;
-
+    /** Dynamic local buffer registration by clients**/
+    char *famClientBuffer;
 } Fam_Options;
+
 #ifdef __cplusplus
 }
 #endif
@@ -361,6 +360,26 @@ class Fam_Region_Descriptor {
 
 class fam_context;
 
+typedef enum {
+    /** Register a new client buffer **/
+    REGISTER = 0,
+    /** Deregister an existing client buffer registered previously **/
+    DEREGISTER
+} Fam_Buff_Op;
+
+typedef struct Fam_Client_Buffer {
+    /** Client buffer to register **/
+    void *buffer;
+    /** Size of the client buffer to be registered **/
+    size_t bufferSize;
+    /** Context where the buffer is registered. Unless specified, registered with the default context **/
+    fam_context *ctx;
+    /** Can take value "REGISTER" or "DEREGISTER" **/
+    Fam_Buff_Op op;
+
+    Fam_Client_Buffer() : buffer(NULL), bufferSize(0), ctx(NULL) {}
+} Fam_Client_Buffer;
+
 class fam {
   public:
     // INITIALIZE group
@@ -414,6 +433,11 @@ class fam {
      * @see #fam_list_options()
      */
     const void *fam_get_option(char *optionName);
+
+    /** 
+     * TODO: add descriptions
+     */
+    void fam_set_option(char *optionName, void *value, size_t valueSize);
 
     /**
      * Look up a region in FAM by name in the name service.
@@ -1286,6 +1310,7 @@ class fam_context : public fam {
     void fam_barrier_all();
     const char **fam_list_options(void);
     const void *fam_get_option(char *optionName);
+    void fam_set_option(char *optionName, void *value, size_t valueSize);
     Fam_Region_Descriptor *fam_lookup_region(const char *name);
     Fam_Descriptor *fam_lookup(const char *itemName, const char *regionName);
 

--- a/src/common/fam_ops.h
+++ b/src/common/fam_ops.h
@@ -750,6 +750,11 @@ class Fam_Ops {
 
     /* Local Buffer heap register passed by application */
     virtual void register_heap(void *base, size_t len) = 0;
+    virtual void register_heap(uint64_t contextID, void *base, size_t len) = 0;
+
+    /* Deregister Local Buffer heap */
+    virtual void deregister_heap(void *base, size_t len) = 0;
+    virtual void deregister_heap(uint64_t contextID, void *base, size_t len) = 0;
 };
 
 #endif

--- a/src/common/fam_ops_libfabric.h
+++ b/src/common/fam_ops_libfabric.h
@@ -380,6 +380,8 @@ class Fam_Ops_Libfabric : public Fam_Ops {
 
     Fam_Context *get_context(Fam_Descriptor *descriptor);
 
+    Fam_Context *get_context(uint64_t contextID);
+
     void quiet_context(Fam_Context *context);
 
     uint64_t progress_context();
@@ -410,6 +412,9 @@ class Fam_Ops_Libfabric : public Fam_Ops {
     size_t get_fabric_iov_limit() { return fabric_iov_limit; }
     size_t get_fabric_max_msg_size() { return fabric_max_msg_size; }
     void register_heap(void *base, size_t len);
+    void register_heap(uint64_t contextID, void *base, size_t len);
+    void deregister_heap(void *base, size_t len);
+    void deregister_heap(uint64_t contextID, void *base, size_t len);
 
   protected:
     // Server_Map name;

--- a/src/common/fam_ops_shm.h
+++ b/src/common/fam_ops_shm.h
@@ -308,6 +308,9 @@ class Fam_Ops_SHM : public Fam_Ops {
     void context_close(uint64_t contextId);
     uint64_t get_context_id();
     void register_heap(void *base, size_t len) {}
+    void register_heap(uint64_t contextID, void *base, size_t len) {}
+    void deregister_heap(void *base, size_t len) {}
+    void deregister_heap(uint64_t contextID, void *base, size_t len) {}
 
   protected:
     Fam_Async_QHandler *asyncQHandler;

--- a/src/common/fam_options.h
+++ b/src/common/fam_options.h
@@ -74,10 +74,8 @@ typedef enum {
     FAM_DEFAULT_MEMORY_TYPE,
     /** Interface device used by the PE for communication */
     IF_DEVICE,
-    /** Local Buffer Address passed by Application */
-    LOC_BUF_ADDR,
-    /** Local Buffer size passed by Application */
-    LOC_BUF_SIZE,
+    /** Dynamic local buffer registration by clients **/
+    FAM_CLIENT_BUFFER,
     /** END of Option keys */
     END_OPT = -1
 } Fam_Option_Key;
@@ -103,6 +101,8 @@ typedef enum {
 #define FAM_OPTIONS_RUNTIME_PMIX_STR "PMIX"
 #define FAM_OPTIONS_RUNTIME_PMI2_STR "PMI2"
 #define FAM_OPTIONS_RUNTIME_NONE_STR "NONE"
+
+#define FAM_CLIENT_BUFFER_STR "FAM_CLIENT_BUFFER"
 
 typedef enum {
     /** For single threaded applicaiton */

--- a/src/fam-api/fam.cpp
+++ b/src/fam-api/fam.cpp
@@ -93,9 +93,8 @@ const char *supportedOptionList[] = {
     "NUM_CONSUMER",            // index #12
     "FAM_DEFAULT_MEMORY_TYPE", // index #13
     "IF_DEVICE",               // index #14
-    "LOC_BUF_ADDR",            // index #15
-    "LOC_BUF_SIZE",            // index #16
-    NULL                       // index #17
+    "FAM_CLIENT_BUFFER",       // index #15
+    NULL                       // index #16
 };
 
 namespace openfam {
@@ -133,10 +132,6 @@ class fam::Impl_ {
             famOps = new Fam_Ops_Libfabric((Fam_Ops_Libfabric *)pimpl->famOps);
             ctxId = famOps->get_context_id();
             pimpl->famOps->context_open(ctxId, famOps);
-            if (((pimpl->famOptions).local_buf_size != 0) &&
-                    ((pimpl->famOptions).local_buf_addr != NULL))
-                famOps->register_heap((pimpl->famOptions).local_buf_addr,
-                                  (pimpl->famOptions).local_buf_size);
         }
         famAllocator = pimpl->famAllocator;
         famRuntime = pimpl->famRuntime;
@@ -169,6 +164,8 @@ class fam::Impl_ {
 
     void fam_context_close(fam_context *ctx);
 
+    uint64_t fam_get_context_id();
+
     void fam_abort(int status);
 
     void fam_barrier_all(void);
@@ -176,6 +173,8 @@ class fam::Impl_ {
     const char **fam_list_options(void);
 
     const void *fam_get_option(char *optionName);
+    
+    void fam_set_option(char *optionName, void *value, size_t valueSize);
 
     Fam_Region_Descriptor *fam_lookup_region(const char *name);
 
@@ -696,6 +695,8 @@ void fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
 
     optValueMap->insert({supportedOptionList[VERSION], strdup(OPENFAM_VERSION)});
 
+    optValueMap->insert({supportedOptionList[FAM_CLIENT_BUFFER], strdup(FAM_CLIENT_BUFFER_STR)});
+
     // Look for options information from config file.
     std::string config_file_path;
     configFileParams file_options;
@@ -797,12 +798,6 @@ void fam::Impl_::fam_initialize(const char *grpName, Fam_Options *options) {
                 famRuntime->runtime_fini();
             THROW_ERR_MSG(Fam_Datapath_Exception, message.str().c_str());
         }
-        else {
-            if(famOptions.local_buf_size != 0 &&
-                    famOptions.local_buf_addr != NULL) {
-                famOps->register_heap(famOptions.local_buf_addr , famOptions.local_buf_size);
-            }
-        }
     }
     FAM_PROFILE_END_ALLOCATOR(fam_initialize);
 }
@@ -816,24 +811,6 @@ int fam::Impl_::validate_fam_options(Fam_Options *options,
 
     int ret = 0;
     std::ostringstream message;
-    if (options && options->local_buf_addr && options->local_buf_size) {
-        famOptions.local_buf_addr = options->local_buf_addr;
-        famOptions.local_buf_size = options->local_buf_size;
-    } else {
-        famOptions.local_buf_addr = NULL;
-        famOptions.local_buf_size = 0;
-    }
-    char *addr_str = (char *)malloc(20 * sizeof(char));
-    if (famOptions.local_buf_addr != NULL)
-        sprintf(addr_str, "%p", (void *)famOptions.local_buf_addr);
-    else
-        sprintf(addr_str, "0");
-    optValueMap->insert({supportedOptionList[LOC_BUF_ADDR], addr_str});
-
-    uint64_t *local_buf_size_opt = (uint64_t *)malloc(sizeof(uint64_t));
-    *local_buf_size_opt = famOptions.local_buf_size;
-    optValueMap->insert(
-        {supportedOptionList[LOC_BUF_SIZE], local_buf_size_opt});
 
     if (options && options->defaultRegionName)
         famOptions.defaultRegionName = strdup(options->defaultRegionName);
@@ -1020,6 +997,10 @@ void fam::Impl_::fam_context_close(fam_context *ctx) {
         // Delete this list during fam_finalize
         // ctxList->erase(it);
     }
+}
+
+uint64_t fam::Impl_::fam_get_context_id() {
+    return famOps->get_context_id();
 }
 
 /**
@@ -1258,13 +1239,57 @@ const void *fam::Impl_::fam_get_option(char *optionName) {
             int *optVal = (int *)malloc(sizeof(int));
             *optVal = *((int *)opt->second);
             return optVal;
-        }
-        if (strncmp(optionName, "LOC_BUF_SIZE", 12) == 0) {
-            uint64_t *optVal = (uint64_t *)malloc(sizeof(uint64_t));
-            *optVal = *((uint64_t *)opt->second);
-            return optVal;
-        } else
+        } else {
             return strdup((const char *)opt->second);
+        }
+    }
+}
+
+/**
+ * TODO: descriptions to be added
+ */
+void fam::Impl_::fam_set_option(char *optionName, void *value, size_t valueSize) {
+    auto opt = optValueMap->find(optionName);
+    if (opt == optValueMap->end()) {
+        std::ostringstream message;
+        message << "Fam Option not supported: " << optionName;
+        THROW_ERR_MSG(Fam_InvalidOption_Exception, message.str().c_str());
+    } else {
+        if (strncmp(optionName, "FAM_CLIENT_BUFFER", 17) == 0) {
+            if (valueSize == sizeof(Fam_Client_Buffer)) {
+                Fam_Client_Buffer *optionValue = (Fam_Client_Buffer *)value;
+                if (optionValue->ctx == NULL) {
+                    if (optionValue->op == REGISTER) {
+                        famOps->register_heap(optionValue->buffer, optionValue->bufferSize);
+                    } else if (optionValue->op == DEREGISTER) {
+                        famOps->deregister_heap(optionValue->buffer, optionValue->bufferSize);
+                    } else {
+                        std::ostringstream message;
+                        message << "Wrong buffer registration option: " << optionValue->op;
+                        THROW_ERR_MSG(Fam_InvalidOption_Exception, message.str().c_str());
+                    }
+                } else {
+                    uint64_t ctxId = optionValue->ctx->pimpl_->fam_get_context_id();
+                    if (optionValue->op == REGISTER) {
+                        famOps->register_heap(ctxId, optionValue->buffer, optionValue->bufferSize);
+                    } else if (optionValue->op == DEREGISTER) {
+                        famOps->deregister_heap(ctxId, optionValue->buffer, optionValue->bufferSize);
+                    } else {
+                        std::ostringstream message;
+                        message << "Wrong buffer registration option: " << optionValue->op;
+                        THROW_ERR_MSG(Fam_InvalidOption_Exception, message.str().c_str());
+                    }
+                }
+            } else {
+                std::ostringstream message;
+                message << "Wrong option value (size mismatch): " << valueSize;
+                THROW_ERR_MSG(Fam_InvalidOption_Exception, message.str().c_str());
+            }
+        } else {
+            std::ostringstream message;
+            message << "Fam Option not supported: " << optionName;
+            THROW_ERR_MSG(Fam_InvalidOption_Exception, message.str().c_str());
+        }
     }
 }
 
@@ -5484,6 +5509,15 @@ const void *fam::fam_get_option(char *optionName) {
 }
 
 /**
+ * TODO: Description to be added
+ */
+void fam::fam_set_option(char *optionName, void *value, size_t valueSize) {
+    TRY_CATCH_BEGIN
+    return pimpl_->fam_set_option(optionName, value, valueSize);
+    RETURN_WITH_FAM_EXCEPTION
+}
+
+/**
  * Look up a region in FAM by name in the name service.
  * @param name - name of the region.
  * @throws Fam_Allocator_Exception - excptObj->fam_error() may return:
@@ -7003,6 +7037,11 @@ const char **fam_context::fam_list_options(void) {
 const void *fam_context::fam_get_option(char *optionName) {
     THROW_ERRNO_MSG(Fam_Exception, FAM_ERR_NOPERM,
                     "fam_get_option cannot be invoked from fam_context object");
+}
+
+void fam_context::fam_set_option(char *optionName, void *value, size_t valueSize) {
+    THROW_ERRNO_MSG(Fam_Exception, FAM_ERR_NOPERM,
+                    "fam_set_option cannot be invoked from fam_context object");
 }
 
 Fam_Region_Descriptor *fam_context::fam_lookup_region(const char *name) {

--- a/test/unit-test/fam-api/fam_options_test.cpp
+++ b/test/unit-test/fam-api/fam_options_test.cpp
@@ -46,12 +46,8 @@ int main() {
     const char **optList;
     int i = 0;
     init_fam_options(&fam_opts);
-    fam_opts.grpcPort = strdup("9500");
-    fam_opts.runtime = strdup("NONE");
-    int *gBuf = (int *) malloc(sizeof(int));
-    fam_opts.local_buf_addr = gBuf;
-    fam_opts.local_buf_size = sizeof(int);
-
+    //fam_opts.grpcPort = strdup("9500");
+    //fam_opts.runtime = strdup("NONE");
 
     try {
         // Throws grpc exception because of wrong grpc port.
@@ -86,16 +82,6 @@ int main() {
                 cout << "Error msg: " << e.fam_error_msg() << endl;
                 cout << "Error: " << e.fam_error() << endl;
             }
-        } else if (strncmp(opt, "LOC_BUF_SIZE", 12) == 0) {
-            try{
-                size_t *optIntValue = (size_t *)my_fam->fam_get_option(opt);
-                cout << optList[i] << ":" << *optIntValue << endl;
-                free(optIntValue);
-            } catch (Fam_Exception &e) {
-                cout << "Exception caught" << endl;
-                cout << "Error msg: " << e.fam_error_msg() << endl;
-                cout << "Error: " << e.fam_error() << endl;
-            }
         } else {
             try{
                 char *optValue = (char *)my_fam->fam_get_option(opt);
@@ -120,6 +106,67 @@ int main() {
         cout << "Error msg: " << e.fam_error_msg() << endl;
         cout << "Error: " << e.fam_error() << endl;
     }
+
+    char bufRegOpt[20] = "FAM_CLIENT_BUFFER";
+
+    Fam_Client_Buffer *bufRegInfo1 = new Fam_Client_Buffer();
+    bufRegInfo1->buffer = malloc(4096);
+    bufRegInfo1->bufferSize = 4096;
+    bufRegInfo1->op = REGISTER;
+
+    try {
+        my_fam->fam_set_option(bufRegOpt, (void *)bufRegInfo1, sizeof(Fam_Client_Buffer));
+    } catch (Fam_Exception &e) {
+        cout << "Exception caught" << endl;
+        cout << "Error msg: " << e.fam_error_msg() << endl;
+        cout << "Error: " << e.fam_error() << endl;
+    }
+
+    bufRegInfo1->op = DEREGISTER;
+    try {
+        my_fam->fam_set_option(bufRegOpt, (void *)bufRegInfo1, sizeof(Fam_Client_Buffer));
+    } catch (Fam_Exception &e) {
+        cout << "Exception caught" << endl;
+        cout << "Error msg: " << e.fam_error_msg() << endl;
+        cout << "Error: " << e.fam_error() << endl;
+    }
+
+    free(bufRegInfo1->buffer);
+    delete bufRegInfo1;
+
+    Fam_Client_Buffer *bufRegInfo2 = new Fam_Client_Buffer();
+    bufRegInfo2->buffer = malloc(4096);
+    bufRegInfo2->bufferSize = 4096;
+    bufRegInfo2->ctx = my_fam->fam_context_open();
+    bufRegInfo2->op = REGISTER;
+
+    try {
+        my_fam->fam_set_option(bufRegOpt, (void *)bufRegInfo2, sizeof(Fam_Client_Buffer));
+    } catch (Fam_Exception &e) {
+        cout << "Exception caught" << endl;
+        cout << "Error msg: " << e.fam_error_msg() << endl;
+        cout << "Error: " << e.fam_error() << endl;
+    }
+
+    bufRegInfo2->op = DEREGISTER;
+    try {
+        my_fam->fam_set_option(bufRegOpt, (void *)bufRegInfo2, sizeof(Fam_Client_Buffer));
+    } catch (Fam_Exception &e) {
+        cout << "Exception caught" << endl;
+        cout << "Error msg: " << e.fam_error_msg() << endl;
+        cout << "Error: " << e.fam_error() << endl;
+    }
+
+    try {
+        my_fam->fam_context_close(bufRegInfo2->ctx);
+    } catch (Fam_Exception &e) {
+        cout << "Exception caught" << endl;
+        cout << "Error msg: " << e.fam_error_msg() << endl;
+        cout << "Error: " << e.fam_error() << endl;
+    }
+
+    free(bufRegInfo2->buffer);
+    delete bufRegInfo2;
 
     free(optList);
 


### PR DESCRIPTION
In this commit, we introduce the new fam_set_option() method to support dynamic client buffer registration. We provide the new option `FAM_CLIENT_BUFFER` and a struct `Fam_Client_Buffer`. To register/deregister a local buffer, users need to specify the buffer address, size, fam_context object, and opcode (REGISTER or DEREGISTER) to the struct `Fam_Client_Buffer`. If fam_context object is specified, we use it for buffer registration. Otherwise, the default context is used.

Known limitations
- The current implementation does not support the same buffer registration within a context or across multiple contexts.
