### PR TITLE
Make Fam_Exception accept const exceptions

### DIFF
--- a/include/fam/fam_exception.h
+++ b/include/fam/fam_exception.h
@@ -84,11 +84,11 @@ class Fam_Exception : public std::exception {
 
     Fam_Exception &operator=(const Fam_Exception &other);
 
-    virtual char const *fam_error_msg();
+    virtual char const *fam_error_msg() const noexcept;
 
-    virtual int fam_error();
+    virtual int fam_error() const noexcept;
 
-    virtual char const *what();
+    virtual char const *what() const noexcept;
 
   protected:
     std::string famErrMsg;

--- a/src/common/fam_exception.cpp
+++ b/src/common/fam_exception.cpp
@@ -55,10 +55,16 @@ Fam_Exception &Fam_Exception::operator=(const Fam_Exception &other) {
     return *this;
 }
 
-char const *Fam_Exception::fam_error_msg() { return famErrMsg.c_str(); }
+char const *Fam_Exception::fam_error_msg() const noexcept {
+    return famErrMsg.c_str();
+}
 
-char const *Fam_Exception::what() { return famErrMsg.c_str(); }
+char const *Fam_Exception::what() const noexcept {
+    return famErrMsg.c_str();
+}
 
-int Fam_Exception::fam_error() { return famErr; }
+int Fam_Exception::fam_error() const noexcept {
+    return famErr;
+}
 
 } // namespace openfam


### PR DESCRIPTION
Just a nit. Since C11, the base std::exception what() method has been const noexcept; make the Fam_Exception error reporting methods have the same attributes. The allows programmers to catch const Fam_Exceptions and still get the error information.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>