### PR TITLE
Fix #289

### DIFF
--- a/test/unit-test/fam-api/fam_options_test.cpp
+++ b/test/unit-test/fam-api/fam_options_test.cpp
@@ -123,17 +123,6 @@ int main() {
 
     free(optList);
 
-    // Test fam_context_open/close after local buffer registrations
-    try {
-        fam_context *ctx = my_fam->fam_context_open();
-        ctx->fam_quiet();
-        my_fam->fam_context_close(ctx);
-    } catch (Fam_Exception &e) {
-        cout << "Exception caught" << endl;
-        cout << "Error msg: " << e.fam_error_msg() << endl;
-        cout << "Error: " << e.fam_error() << endl;
-    }
-
     try {
         my_fam->fam_finalize("default");
         cout << "fam finalize successful" << endl;


### PR DESCRIPTION
The unit-test, fam_options_test, resulted in a segmentation fault consistently. So when it was backtracked to see why this issue occurs, it was noticed that in this [file](https://github.com/OpenFAM/OpenFAM/blob/devel/test/unit-test/fam-api/fam_options_test.cpp), we are testing out a negative scenario by setting an invalid gRPC port number in fam_options and so fam_initialize fails and throws an exception as expected. Subsequent calls to list and validate the fam options work fine.

    fam_opts.grpcPort = strdup("9500");
    fam_opts.runtime = strdup("NONE");
    int *gBuf = (int *)malloc(sizeof(int));
    fam_opts.local_buf_addr = gBuf;
    fam_opts.local_buf_size = sizeof(int);

    try {
        // Throws grpc exception because of wrong grpc port.
        // Continue the test, as this is only to test fam_options.
        my_fam->fam_initialize("default", &fam_opts);
    } catch (Fam_Exception &e) {
        cout << "fam initialization failed with fam_error:" << e.fam_error()
             << ":" << e.fam_error_msg()
             << ", continue to test fam_list_options." << endl;
    }

Now the last commit that was added to the devel branch (https://github.com/OpenFAM/OpenFAM/pull/277), consist of changes to fix the duplicate local buffer registration from fam_context_open() and in this commit there is an additional test case that has been added to the [fam_options_test.cpp file](https://github.com/OpenFAM/OpenFAM/pull/277/files#diff-51d0dd6caf73269a531f3f0d1cfad81ee7339cd923753cfb9169212e94ee1da9), which tests fam_context_open()/fam_context_close() calls using the invalid fam descriptor due to reason mentioned above, resulting in a failure scenario. Hence that test case has been omitted in this commit.