### PR TITLE
Fix python3 version in adm tool during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ test/microbench/fam-api-mb/scripts/single-mem-test-arg.txt
 test/services-test/multi_mem_persistent.txt
 test/services-test/multi_mem_volatile.txt
 test/config_files
+tools/openfam_adm.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
  #
  # CMakeLists.txt
- # Copyright (c) 2019-2023 Hewlett Packard Enterprise Development, LP. All rights reserved.
+ # Copyright (c) 2019-2023,2025 Hewlett Packard Enterprise Development, LP. All rights reserved.
  # Redistribution and use in source and binary forms, with or without modification, are permitted provided
  # that the following conditions are met:
  # 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
@@ -220,6 +220,47 @@ configure_file( ${PROJECT_SOURCE_DIR}/test/common/fam_test_config.h.in ${PROJECT
 # Read version number from VERSION file
 file(STRINGS "VERSION" VERSION_STR)
 add_definitions(-DOPENFAM_VERSION="${VERSION_STR}")
+
+# Find Python3 from system PATH
+find_program(Python3_EXECUTABLE python3)
+
+# Ensure Python3_EXECUTABLE is found
+if(NOT Python3_EXECUTABLE)
+    message(FATAL_ERROR "Python3 executable not found in the system PATH.")
+endif()
+
+# Debug message to verify the detected Python3 executable
+message(STATUS "System default Python3 executable: ${Python3_EXECUTABLE}")
+
+# Ensure the detected Python version meets the minimum requirement
+find_package(Python3 REQUIRED)
+if(Python3_VERSION VERSION_LESS "3.6")
+    message(FATAL_ERROR "Python 3.6 or higher is required. Detected version: ${Python3_VERSION}")
+endif()
+
+# Get the Python version
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} --version
+    OUTPUT_VARIABLE PYTHON_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Extract the Python version from output
+string(REGEX MATCH "[0-9]+\\.[0-9]+" PYTHON_FULL_VERSION "${PYTHON_VERSION_OUTPUT}")
+
+# Construct the full Python executable path
+get_filename_component(PYTHON_EXECUTABLE_DIR ${Python3_EXECUTABLE} DIRECTORY)
+set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DIR}/python${PYTHON_FULL_VERSION}")
+
+# Debug message to verify the full Python executable path
+message(STATUS "Full Python executable: ${PYTHON_EXECUTABLE}")
+
+# Configure the Python script with the detected Python executable
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/tools/openfam_adm_template.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/tools/openfam_adm.py
+    @ONLY
+)
 
 #
 # add source code

--- a/tools/openfam_adm_template.py
+++ b/tools/openfam_adm_template.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python3
+#!@PYTHON_EXECUTABLE@
 # openfam_adm.py
-# Copyright (c) 2022-2023 Hewlett Packard Enterprise Development, LP. All rights reserved.
+# Copyright (c) 2022-2023,2025 Hewlett Packard Enterprise Development, LP. All rights reserved.
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided
 # that the following conditions are met:
 # 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
@@ -29,6 +29,16 @@ import re
 import subprocess
 from pathlib import Path
 from tabulate import tabulate
+
+# Minimum required Python version
+MIN_PYTHON_VERSION = (3, 6)
+
+# Check if the current Python version meets the minimum requirement
+if sys.version_info < MIN_PYTHON_VERSION:
+    sys.stderr.write(
+        f"ERROR: Python {MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or higher is required.\n"
+    )
+    sys.exit(1)
 
 # Create the parser
 
@@ -335,30 +345,40 @@ if args.create_config_files:
 
     # Open all config file templates
     with open(openfam_install_path + "/config/fam_pe_config.yaml") as pe_config_infile:
-        pe_config_doc = ruamel.yaml.load(
-            pe_config_infile, ruamel.yaml.RoundTripLoader)
+        yaml = ruamel.yaml.YAML(typ='rt')
+        yaml.RoundTripLoader = True
+        pe_config_doc = yaml.load(
+            pe_config_infile)
     with open(
         openfam_install_path + "/config/fam_client_interface_config.yaml"
     ) as cis_config_infile:
-        cis_config_doc = ruamel.yaml.load(
-            cis_config_infile, ruamel.yaml.RoundTripLoader)
+        yaml = ruamel.yaml.YAML(typ='rt')
+        yaml.RoundTripLoader = True
+        cis_config_doc = yaml.load(
+            cis_config_infile)
     with open(
         openfam_install_path + "/config/fam_memoryserver_config.yaml"
     ) as memservice_config_infile:
-        memservice_config_doc = ruamel.yaml.load(
-            memservice_config_infile, ruamel.yaml.RoundTripLoader
+        yaml = ruamel.yaml.YAML(typ='rt')
+        yaml.RoundTripLoader = True
+        memservice_config_doc = yaml.load(
+            memservice_config_infile
         )
     with open(
         openfam_install_path + "/config/fam_metadata_config.yaml"
     ) as metaservice_config_infile:
-        metaservice_config_doc = ruamel.yaml.load(
-            metaservice_config_infile, ruamel.yaml.RoundTripLoader
+        yaml = ruamel.yaml.YAML(typ='rt')
+        yaml.RoundTripLoader = True
+        metaservice_config_doc = yaml.load(
+            metaservice_config_infile
         )
     with open(
         openfam_install_path + "/config/openfam_admin_tool.yaml"
     ) as openfam_admin_tool_config_infile:
-        openfam_admin_tool_config_doc = ruamel.yaml.load(
-            openfam_admin_tool_config_infile, ruamel.yaml.RoundTripLoader
+        yaml = ruamel.yaml.YAML(typ='rt')
+        yaml.RoundTripLoader = True
+        openfam_admin_tool_config_doc = yaml.load(
+            openfam_admin_tool_config_infile
         )
 
     if args.model is not None:
@@ -616,38 +636,45 @@ if args.create_config_files:
     cmd = "mkdir -p " + args.config_file_path + "/config"
     os.system(cmd)
     with open(args.config_file_path + "/config/fam_pe_config.yaml", "w") as pe_config_outfile:
-        ruamel.yaml.dump(
-            pe_config_doc, pe_config_outfile, Dumper=ruamel.yaml.RoundTripDumper
+        yaml = ruamel.yaml.YAML()
+        yaml.RoundTripDumper = True
+        yaml.dump(
+            pe_config_doc, pe_config_outfile
         )
     with open(
         args.config_file_path + "/config/fam_client_interface_config.yaml", "w"
     ) as cis_config_outfile:
-        ruamel.yaml.dump(
-            cis_config_doc, cis_config_outfile, Dumper=ruamel.yaml.RoundTripDumper
+        yaml = ruamel.yaml.YAML()
+        yaml.RoundTripDumper = True
+        yaml.dump(
+            cis_config_doc, cis_config_outfile
         )
     with open(
         args.config_file_path + "/config/fam_memoryserver_config.yaml", "w"
     ) as memservice_config_outfile:
-        ruamel.yaml.dump(
+        yaml = ruamel.yaml.YAML()
+        yaml.RoundTripDumper = True
+        yaml.dump(
             memservice_config_doc,
-            memservice_config_outfile,
-            Dumper=ruamel.yaml.RoundTripDumper,
+            memservice_config_outfile
         )
     with open(
         args.config_file_path + "/config/fam_metadata_config.yaml", "w"
     ) as metaservice_config_outfile:
-        ruamel.yaml.dump(
+        yaml = ruamel.yaml.YAML()
+        yaml.RoundTripDumper = True
+        yaml.dump(
             metaservice_config_doc,
-            metaservice_config_outfile,
-            Dumper=ruamel.yaml.RoundTripDumper,
+            metaservice_config_outfile
         )
     with open(
         args.config_file_path + "/config/openfam_admin_tool.yaml", "w"
     ) as openfam_admin_tool_config_outfile:
-        ruamel.yaml.dump(
+        yaml = ruamel.yaml.YAML()
+        yaml.RoundTripDumper = True
+        yaml.dump(
             openfam_admin_tool_config_doc,
-            openfam_admin_tool_config_outfile,
-            Dumper=ruamel.yaml.RoundTripDumper,
+            openfam_admin_tool_config_outfile
         )
 
     if not args.start_service:
@@ -686,30 +713,40 @@ else:
     else:
         openfam_config_path = os.environ["OPENFAM_ROOT"]
 with open(openfam_config_path + "/config/fam_pe_config.yaml") as pe_config_infile:
-    pe_config_doc = ruamel.yaml.load(
-        pe_config_infile, ruamel.yaml.RoundTripLoader)
+    yaml = ruamel.yaml.YAML(typ='rt')
+    yaml.RoundTripLoader = True
+    pe_config_doc = yaml.load(
+        pe_config_infile)
 with open(
     openfam_config_path + "/config/fam_client_interface_config.yaml"
 ) as cis_config_infile:
-    cis_config_doc = ruamel.yaml.load(
-        cis_config_infile, ruamel.yaml.RoundTripLoader)
+    yaml = ruamel.yaml.YAML(typ='rt')
+    yaml.RoundTripLoader = True
+    cis_config_doc = yaml.load(
+        cis_config_infile)
 with open(
     openfam_config_path + "/config/fam_memoryserver_config.yaml"
 ) as memservice_config_infile:
-    memservice_config_doc = ruamel.yaml.load(
-        memservice_config_infile, ruamel.yaml.RoundTripLoader
+    yaml = ruamel.yaml.YAML(typ='rt')
+    yaml.RoundTripLoader = True
+    memservice_config_doc = yaml.load(
+        memservice_config_infile
     )
 with open(
     openfam_config_path + "/config/fam_metadata_config.yaml"
 ) as metaservice_config_infile:
-    metaservice_config_doc = ruamel.yaml.load(
-        metaservice_config_infile, ruamel.yaml.RoundTripLoader
+    yaml = ruamel.yaml.YAML(typ='rt')
+    yaml.RoundTripLoader = True
+    metaservice_config_doc = yaml.load(
+        metaservice_config_infile
     )
 with open(
     openfam_config_path + "/config/openfam_admin_tool.yaml"
 ) as openfam_admin_tool_config_infile:
-    openfam_admin_tool_config_doc = ruamel.yaml.load(
-        openfam_admin_tool_config_infile, ruamel.yaml.RoundTripLoader
+    yaml = ruamel.yaml.YAML(typ='rt')
+    yaml.RoundTripLoader = True
+    openfam_admin_tool_config_doc = yaml.load(
+        openfam_admin_tool_config_infile
     )
 
 # Assign values to config options if corresponding argument is set
@@ -1122,4 +1159,3 @@ if args.clean:
                 cmd = "rm -rf " + metaservice_config_doc["metadata_path"]
             os.system(cmd)
     print("All FAM and Metadata are cleared")
-


### PR DESCRIPTION
- This PR adds changes to dynamically update and check the python3 version as per the user PATH in the adm tool using CMake during the build process.
- A template file has been added to create and write the updated contents to the openfam_adm.py script when generating the make files.
- The openfam_adm.py file has now been listed under the .gitignore so as to prevent tracking this file on every build.
- It also inherits changes to make use of ruamel.yaml.YAML(typ='rt') from the commit "update ruamel.yaml in adm tool" under PR #288 
- Code changes have passed all unit and regression test cases.