### PR TITLE
Account for behavior change to CXI counters

### DIFF
--- a/src/common/fam_context.cpp
+++ b/src/common/fam_context.cpp
@@ -38,6 +38,12 @@
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
 
+#ifdef __has_include
+#if __has_include(<rdma/fi_cxi_ext.h>)
+#include <rdma/fi_cxi_ext.h>
+#endif
+#endif
+
 #include "common/fam_context.h"
 #include "common/fam_libfabric.h"
 #include "common/fam_options.h"
@@ -109,7 +115,7 @@ Fam_Context::Fam_Context(struct fi_info *fi, struct fid_domain *domain,
         THROW_ERR_MSG(Fam_Datapath_Exception, message.str().c_str());
     }
 
-    ret = initialize_cntr(domain, &txCntr);
+    ret = initialize_cntr(fi, domain, &txCntr);
     if (ret < 0) {
         // print_fierr("initialize_cntr", ret);
         // return -1;
@@ -128,7 +134,7 @@ Fam_Context::Fam_Context(struct fi_info *fi, struct fid_domain *domain,
         THROW_ERR_MSG(Fam_Datapath_Exception, message.str().c_str());
     }
 
-    ret = initialize_cntr(domain, &rxCntr);
+    ret = initialize_cntr(fi, domain, &rxCntr);
     if (ret < 0) {
         // print_fierr("initialize_cntr", ret);
         // return -1;
@@ -156,17 +162,33 @@ Fam_Context::~Fam_Context() {
     pthread_rwlock_destroy(&ctxRWLock);
 }
 
-int Fam_Context::initialize_cntr(struct fid_domain *domain,
+static void initialize_cntr_attr(struct fi_cntr_attr &cntrAttr,
+                                 bool is_cxi, bool cached) {
+    memset(&cntrAttr, 0, sizeof(cntrAttr));
+    cntrAttr.events = FI_CNTR_EVENTS_COMP;
+    cntrAttr.wait_obj = FI_WAIT_UNSPEC;
+#ifdef FI_CXI_CNTR_CACHED
+    if (is_cxi && cached)
+        cntrAttr.flags |= FI_CXI_CNTR_CACHED;
+#endif
+}
+
+int Fam_Context::initialize_cntr(struct fi_info *fi, struct fid_domain *domain,
                                  struct fid_cntr **cntr) {
     int ret = 0;
     struct fi_cntr_attr cntrAttr;
     std::ostringstream message;
+    bool is_cxi = !strcmp(fi->fabric_attr->prov_name, "cxi");
 
-    memset(&cntrAttr, 0, sizeof(cntrAttr));
-    cntrAttr.events = FI_CNTR_EVENTS_COMP;
-    cntrAttr.wait_obj = FI_WAIT_UNSPEC;
+    initialize_cntr_attr(cntrAttr, is_cxi, true);
 
     ret = fi_cntr_open(domain, &cntrAttr, cntr, cntr);
+    // Try for some backwards compatibility
+    if (ret == -FI_ENOSYS && is_cxi) {
+        // The fi_cntr_open() API does not make attr a const.
+        initialize_cntr_attr(cntrAttr, is_cxi, false);
+        ret = fi_cntr_open(domain, &cntrAttr, cntr, cntr);
+    }
     if (ret < 0) {
         message << "Fam libfabric fi_cntr_open failed: "
                 << fabric_strerror(ret);

--- a/src/common/fam_context.h
+++ b/src/common/fam_context.h
@@ -91,7 +91,8 @@ class Fam_Context {
 
     uint64_t get_num_rx_ops() { return numRxOps; }
 
-    int initialize_cntr(struct fid_domain *domain, struct fid_cntr **cntr);
+    int initialize_cntr(struct fi_info *fi, struct fid_domain *domain,
+			struct fid_cntr **cntr);
 
     void acquire_RDLock() {
         if (famThreadModel == FAM_THREAD_MULTIPLE)


### PR DESCRIPTION
Previous to NETCASSINI-6335, fi_cntr_read/readerr returned the last cached value while dispatching a counter read asynchronously. Some applications required that API adhere to the defined semantic of returning the current value, which required waiting for the counter to be returned and NETCASSINI-6335 made this the default behavior. This impacted the minimum latency of fam_quiet().

NETCASSINI-6335 additionally added the FI_CXI_CNTR_CACHED flag to provide the previous behavior and this patch enables it, if it is available in the installed libfabric.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>
