### PR TITLE
Revert "Fix: Handle null unique_ptr case for unregistered local buffer"

### DIFF
--- a/src/common/fam_context.cpp
+++ b/src/common/fam_context.cpp
@@ -245,8 +245,6 @@ Fam_Context::get_mr_descs(const void *local_addr, size_t local_size) {
     auto result = test_overlap(mapPtr, start, end);
     if (result.first == 1) {
         ret = result.second->mr_descs_;
-    } else {
-        thread_release_local_mapptr();
     }
 
     // Releases the thread-local map pointer when unique_ptr goes out of scope


### PR DESCRIPTION
Reverts OpenFAM/OpenFAM#299 since this PR has been merged without sign-off.